### PR TITLE
Update startup time for μcharm in comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Uploading  [███████████░░░░░░] 68%  3.2s
 
 | | Python + Rich | Go + Charm | Rust + Ratatui | **μcharm** |
 |---|:---:|:---:|:---:|:---:|
-| **Startup time** | 100ms+ | ~10-20ms | ~2-10ms | **<= 10ms** |
+| **Startup time** | 100ms+ | ~10-20ms | ~2-10ms | **~ 3ms** |
 | **Binary size** | 80MB+ | 2-3MB | 2-5MB | **< 2MB** |
 | **Easy to write** | Yes | Medium | Hard | **Yes** |
 | **Beautiful TUI** | Yes | Yes | Yes | **Yes** |


### PR DESCRIPTION
The README has two different stats for startup time. 
I updated the one in the comparison sheet, to the value that's mentioned further down.

I am assuming, it improved over time?
Value should obviously be the same.