### PR TITLE
Plan Rust migration and harden subprocess handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-15]
 
     steps:
       - uses: actions/checkout@v4
@@ -87,10 +87,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15
             target: aarch64-macos
             artifact: ucharm-macos-aarch64
-          - os: macos-latest
+          - os: macos-15
             target: x86_64-macos
             artifact: ucharm-macos-x86_64
           - os: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15
             target: aarch64-macos
             artifact: ucharm-macos-aarch64
-          - os: macos-latest
+          - os: macos-15
             target: x86_64-macos
             artifact: ucharm-macos-x86_64
           - os: ubuntu-latest
@@ -53,10 +53,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15
             target: aarch64-macos
             artifact: pocketpy-ucharm-macos-aarch64
-          - os: macos-latest
+          - os: macos-15
             target: x86_64-macos
             artifact: pocketpy-ucharm-macos-x86_64
           - os: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Thumbs.db
 # Zig build artifacts
 **/.zig-cache/
 **/zig-out/
+**/zig-pkg/
 
 # Native libraries (build outputs)
 *.dylib

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,8 +5,9 @@ This is the single source of truth for priorities and next steps.
 ## Snapshot
 
 - Goal: build beautiful CLI apps with Python syntax, shipped as tiny, fast binaries.
-- Runtime: PocketPy + runtime Zig modules + Zig loader for universal binaries.
-- Compatibility status: `tests/compat_report_pocketpy.md` shows 50/52 targeted modules at 100% parity (2 have no baseline on older CPython versions). Refresh with `python3 tests/compat_runner.py --report`.
+- Runtime: PocketPy with a Zig host today; the native host, modules, CLI, and loader are migrating to stable Rust.
+- Language decision: Rust is the target implementation language. See `RUST_MIGRATION.md` for gates and sequencing.
+- Compatibility status: `tests/compat_report_pocketpy.md` shows 51/52 targeted modules at 100% parity (1 has no baseline on the host CPython version). Refresh with `python3 tests/compat_runner.py --report`.
 - PocketPy vendor patches are tracked under `pocketpy/patches/` and verified via `python3 scripts/verify-pocketpy-patches.py --check-upstream`.
 
 ## Current State (from the repo)
@@ -16,15 +17,26 @@ This is the single source of truth for priorities and next steps.
 - Stubs exist in `stubs/` and `cli/src/stubs/`; there is a generator script in `scripts/generate_stubs.py`.
 - CPython tests are vendored under `tests/cpython/` and are used to track parity.
 
-## PocketPy Migration Plan
+## Active Priority: Rust Migration
+
+- Freeze new Zig feature work; accept only small correctness, security, and release-blocking fixes.
+- Preserve PocketPy, the Python-facing API, `MCHARM01` universal binaries, and all current compatibility tests.
+- Establish the Rust/PocketPy FFI and four-target build proof before translating the large runtime module surface.
+- Port in releasable slices: loader, CLI using existing assets, runtime foundation, then module waves.
+- Keep Zig and Rust differential tests until each component crosses its parity, size, startup, and target gates.
+- Do not retain Zig indirectly through `cargo-zigbuild` in the final release pipeline.
+
+The detailed inventory, architecture, acceptance gates, PR sequence, and risks are in `RUST_MIGRATION.md`.
+
+## Completed Runtime Decision: PocketPy
 
 ### Phase 1: Runtime switch + tooling (COMPLETE)
 - PocketPy is now the default and only runtime.
 - MicroPython has been removed from the project.
 - `tests/compat_runner.py` defaults to PocketPy.
 
-### Phase 2: Module parity + API surface
-- Keep Zig-only modules as the standard and avoid Python fallback modules.
+### Phase 2: Module parity + API surface (COMPLETE FOR CURRENT TARGET SET)
+- Native modules remain the standard during the Rust port; avoid introducing temporary Python fallbacks that change behavior.
 - Targeted stdlib parity is now at 100% for the current module set (see `tests/compat_report_pocketpy.md`).
 - Maintain parity by re-running `python3 tests/compat_runner.py --report` after runtime changes.
 
@@ -35,27 +47,27 @@ This is the single source of truth for priorities and next steps.
 
 ## What to Focus on Next
 
-1. Keep the compatibility story crisp: document what’s implemented vs intentionally missing, and keep `tests/compat_report_pocketpy.md` current.
-2. Only after module coverage feels good: consolidate stub generation and make it a predictable workflow (one command, single source of truth).
-3. Add CI targets for Vision + compatibility report generation.
-4. Keep cross-target builds working: ensure `ucharm build --target <target>` continues to fetch/run the correct `pocketpy-ucharm` runtime.
-   - In a source checkout, `ucharm build` can build missing target runtimes locally via Zig (no release assets required).
+1. Record the reproducible Zig baseline and add golden/differential fixtures.
+2. Prove Rust-hosted PocketPy and C dependency builds on all four release targets.
+3. Port the universal format/loader, then the CLI around existing runtime assets.
+4. Port the runtime and native modules without allowing compatibility to fall below the current baseline.
+5. Cut CI and releases to Rust, remove Zig, then continue the product roadmap below.
 
-## Plan (near-term)
+## Product Roadmap After the Rust Cutover
 
 ### Phase A: Close feature gap (Vision)
 - Maintain the Vision “nice-to-have” surface (`toml`/`tomllib`, `http.client`, `secrets`, `hmac`, `dataclasses`, `xml.etree`, `sqlite3`, and archive helpers).
 - Keep the suite honest by expanding tests when behavior changes.
 
 ### Phase B: Developer experience
-- Decide the canonical stub source (Zig annotations or `stubs/`) and wire `scripts/generate_stubs.py` or a CLI command to regenerate them.
+- Decide the canonical stub source (Rust registration metadata or `stubs/`) and wire `scripts/generate_stubs.py` or a CLI command to regenerate them.
 - Update templates and docs to reference the canonical stubs and correct import paths.
 
 ### Phase C: Packaging + release hygiene
 - Add a CI step that runs `python3 tests/compat_runner.py --report` and uploads the report as an artifact.
 - Add a CI step that runs `python3 scripts/verify-pocketpy-patches.py --check-upstream`.
 - Validate cross-target build support (`ucharm build --targets` and a sample `--target` build).
- - Consider producing all `pocketpy-ucharm` target runtimes from one host via Zig cross-compilation (may remove the need for a matrix).
+- Prefer native-architecture CI runners for C/Rust release builds; do not reintroduce Zig for cross-compilation.
 
 ## Backlog (ordered)
 

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -1,0 +1,296 @@
+# Rust Migration Plan
+
+## Decision
+
+μcharm will migrate its native implementation from Zig to stable Rust while
+keeping PocketPy as the embedded Python runtime.
+
+This is a host-language and toolchain migration, not a product rewrite. The
+Python-facing API, PocketPy compatibility work, universal-binary behavior, and
+product goals remain in place.
+
+The migration should be incremental. Zig feature work is frozen except for
+small correctness, security, and release-blocking fixes. New product features
+resume on the Rust implementation after the relevant component has crossed its
+parity gate.
+
+## Why Rust Fits This Repository Better
+
+- Rust has a stable language and standard-library contract. Edition changes
+  are opt-in, so routine compiler updates do not require source migrations.
+- PocketPy exposes a C API, which Rust can call through a small, auditable FFI
+  layer without changing the interpreter.
+- Cargo provides a mature dependency, workspace, test, and release model.
+- The supported μcharm targets all have Rust target support. Intel macOS needs
+  explicit CI attention because it is no longer a Rust Tier 1 host target.
+- Rust can still produce stripped, statically linked Linux binaries. Size and
+  startup must be measured rather than assumed, and are hard migration gates.
+- Rust's ownership model is a good fit for the resource-heavy parts of this
+  codebase: VM values, allocators, subprocess pipes, terminal state, temporary
+  files, and embedded runtime extraction.
+
+The decision does not depend on calling Zig a toy. Zig has real strengths,
+especially its cross-compilation and C integration. The repository-specific
+problem is that μcharm has more than 28,000 lines coupled to a pre-1.0 language
+and standard library. For example, the codebase pinned to Zig 0.15.2 does not
+build on Zig 0.16.0 without build API changes. That maintenance cost is now
+larger than the benefit of staying.
+
+## Current Inventory
+
+Tracked first-party Zig code at the start of the migration:
+
+| Area | Files | Lines | Responsibility |
+| --- | ---: | ---: | --- |
+| `runtime/` | 63 | 23,074 | PocketPy modules, TUI, stdlib compatibility |
+| `cli/` | 11 | 2,505 | `ucharm` commands, packaging, target downloads |
+| `pocketpy/` | 4 | 1,533 | VM wrapper, module registration, native build |
+| `loader/` | 4 | 623 | Universal-binary extraction and execution |
+| `shared/` | 1 | 454 | Shared terminal presentation helpers |
+| **Total** | **83** | **28,189** | |
+
+The runtime module layer is the dominant cost and risk. The loader is the
+smallest isolated production component, while the PocketPy FFI is the critical
+technical proof.
+
+Baseline artifacts and performance must be recorded per target in Phase 0.
+One local macOS `ReleaseSmall` build at the decision point produced a 2,313,264
+byte PocketPy runtime and a 98,200 byte loader; these are observations, not the
+cross-platform acceptance baseline.
+
+## Target Architecture
+
+Use one Cargo workspace with a deliberately small crate graph:
+
+```text
+Cargo.toml
+rust-toolchain.toml
+crates/
+├── pocketpy-sys/       # C compilation and raw PocketPy declarations
+├── ucharm-format/      # MCHARM01 trailer, hashes, target names
+├── ucharm-runtime/     # VM ownership and native module registration
+├── ucharm-loader/      # Standalone universal-binary loader
+└── ucharm-cli/         # new/init/run/build/test commands
+```
+
+Runtime modules live under `ucharm-runtime/src/modules/` until there is a
+measured reason to split them into more crates. Avoid recreating the current
+build file's one-module-per-build-node complexity.
+
+### Toolchain policy
+
+- Stable Rust only; no nightly features.
+- Pin an exact compiler in `rust-toolchain.toml` and update it intentionally.
+- Commit `Cargo.lock` and set `rust-version` for every workspace crate.
+- Use the 2024 edition unless a spike finds a concrete blocker.
+- Build release binaries with LTO, one codegen unit, symbol stripping, and
+  `panic = "abort"`; validate crash diagnostics before finalizing that profile.
+- Run `cargo fmt`, `cargo clippy --all-targets --all-features`, and
+  `cargo test --workspace` in CI.
+- Keep dependencies sparse. Prefer the standard library for the existing
+  hand-written CLI parser and binary format.
+
+### C and FFI policy
+
+- Compile PocketPy and the existing C dependencies with the `cc` crate.
+- Generate raw bindings with a pinned development tool, review them, and check
+  them into `pocketpy-sys`; release builds must not require libclang.
+- Keep all raw pointers and C calls inside `pocketpy-sys` and a narrow VM/value
+  wrapper in `ucharm-runtime`.
+- Document ownership for every PocketPy value and callback. No Rust reference
+  may outlive the VM or cross a VM call that can invalidate it.
+- Deny `unsafe_op_in_unsafe_fn` and explain every `unsafe` block with its
+  invariant.
+- Continue vendoring and verifying the PocketPy patch set before compilation.
+
+### Cross-compilation policy
+
+Do not adopt `cargo-zigbuild`; the completed release pipeline must not retain a
+Zig dependency.
+
+- Build macOS ARM64 natively.
+- Build macOS x86_64 on macOS with an explicit x86_64 target and matching C
+  compiler flags; keep it as a tested compatibility target.
+- Build Linux x86_64 with musl on x86_64 Linux.
+- Build Linux ARM64 with musl on an ARM64 runner. Use a conventional musl cross
+  compiler only if native CI is unavailable.
+- Produce hashes and artifact names identical to current releases until a
+  versioned format change is intentionally introduced.
+
+## Non-Negotiable Compatibility Gates
+
+Each cutover PR must preserve these contracts:
+
+1. `tests/compat_runner.py --report` stays at 100% for the currently targeted
+   module set.
+2. The Python imports, function signatures, return shapes, error behavior, and
+   TUI output remain compatible unless a separate product change is approved.
+3. A Rust CLI can consume the existing embedded loader/runtime assets during
+   the transition.
+4. A Rust loader can execute an existing `MCHARM01` universal binary, and a
+   Zig loader can execute one produced by the Rust packager.
+5. All four release targets build and pass smoke tests.
+6. Median warm startup remains at or below 10 ms on the benchmark hosts.
+7. A typical standalone app remains below 2 MB. A temporary exception requires
+   an explicit recorded decision and a size-recovery issue before cutover.
+8. No Zig-built object, compiler, or `cargo-zigbuild` step remains in the final
+   release path.
+
+Keep Zig and Rust jobs side by side until the relevant gate passes. Differential
+tests should run the same Python file through both runtimes and compare exit
+status, stdout, and stderr.
+
+## Execution Plan
+
+### Phase 0 — Freeze and baseline
+
+- Tag or record the last Zig baseline commit and pin Zig 0.15.2 for maintenance.
+- Record clean release sizes, startup distributions, memory use, compatibility
+  results, and universal-build smoke tests on all targets.
+- Add golden tests for the trailer format, CLI help/errors, and representative
+  TUI output before translating those components.
+- Classify every native module as pure computation, OS/terminal integration, or
+  external-C-backed so the port order is explicit.
+
+Exit gate: the baseline is reproducible in CI and contains enough fixtures to
+detect behavioral drift.
+
+### Phase 1 — Prove the Rust spine
+
+- Create the Cargo workspace and pinned toolchain.
+- Build the vendored PocketPy source from `pocketpy-sys`.
+- Implement VM startup, script execution, error propagation, and one trivial
+  native module through the safe wrapper.
+- Produce stripped macOS ARM64 and Linux x86_64 binaries and compare startup and
+  size with the baseline.
+- Prove that the C build can also target macOS x86_64 and Linux ARM64 before
+  broad module translation begins.
+
+Exit gate: a Python script runs through Rust-hosted PocketPy on all release
+targets, the FFI invariants are reviewed, and size/startup are within the
+budget or have a concrete measured recovery plan.
+
+### Phase 2 — Port the universal format and loader
+
+- Implement the 48-byte `MCHARM01` trailer in `ucharm-format` with byte-level
+  golden vectors shared with the Zig tests.
+- Port loader validation, hashing, cache naming, extraction, permissions,
+  cleanup, and `exec` behavior.
+- Test corrupted trailers, truncated binaries, hash mismatches, concurrent
+  launches, cache reuse, and paths containing spaces.
+- Cross-test Rust and Zig packager/loader combinations.
+
+Exit gate: the Rust loader is format-compatible and no slower or materially
+larger than the recorded baseline.
+
+### Phase 3 — Port the CLI around existing runtime assets
+
+- Port `new`, `init`, `run`, `build`, and `test` without redesigning their UX.
+- Embed the already released runtime and loader stubs first. This decouples the
+  CLI migration from native module translation.
+- Preserve target names, download URLs, SHA-256 verification, cache layout,
+  script transformation, exit codes, and diagnostic wording.
+- Add snapshot tests for help and errors plus end-to-end tests for all build
+  modes.
+
+Exit gate: the Rust CLI passes the current unit/e2e suite and can build and run
+universal apps using the existing runtime assets.
+
+### Phase 4 — Port the runtime foundation
+
+- Port the reusable ANSI, argument, TUI, and input core logic.
+- Implement a declarative module registration table so adding a module does not
+  require hundreds of build-script declarations.
+- Centralize PocketPy conversions for strings, bytes, lists, tuples, dicts,
+  callables, exceptions, and userdata.
+- Add leak checks, sanitizer runs for C code, and tests for callback/value
+  lifetime boundaries.
+
+Exit gate: representative `charm`, `input`, and compatibility modules register
+through one reviewed path and survive stress/error tests.
+
+### Phase 5 — Port native modules in risk-ordered waves
+
+Port behavior, not Zig syntax. Every module moves with its existing CPython
+fixture and a Zig-versus-Rust differential run.
+
+1. Pure and low-OS modules: `base64`, `binascii`, `copy`, `fnmatch`, `functools`,
+   `heapq`, `itertools`, `operator`, `statistics`, `textwrap`, `typing`.
+2. Data/model modules: `array`, `collections`, `csv`, `datetime`, `json`, `re`,
+   `struct`, `toml`, `uuid`, XML and dataclasses.
+3. Filesystem and process modules: `os`, `pathlib`, `glob`, `tempfile`, `shutil`,
+   `signal`, `subprocess`, logging, and terminal/input behavior.
+4. External-C-backed and network modules: BearSSL/fetch/HTTP, SQLite,
+   TinyTemplate, hashing/HMAC/secrets, and archive formats.
+5. μcharm presentation modules and interactive golden tests.
+
+Retire each Zig module from the Rust release only when its compatibility group
+returns to 100%.
+
+Exit gate: the complete compatibility suite and interactive/e2e suite pass on
+the Rust runtime for every release target.
+
+### Phase 6 — Cut over CI, packaging, and releases
+
+- Switch `justfile`, CI, release workflows, updater scripts, Homebrew formula,
+  docs, templates, and contributor instructions to Cargo.
+- Build the CLI, runtime, and loaders from Rust/C only and refresh embedded
+  stubs for all targets.
+- Run a release-candidate bake with artifact install, universal build, and
+  execution tests on clean machines.
+- Publish one prerelease before making the Rust artifacts the default stable
+  download.
+
+Exit gate: the normal CI and release workflows contain no Zig setup and all
+artifacts meet the compatibility, startup, and size gates.
+
+### Phase 7 — Remove Zig and resume the roadmap
+
+- Delete Zig sources, build files, caches, and stale embedded binaries only
+  after the Rust release is proven. Preserve the last Zig tag and migration
+  notes for archaeology.
+- Update architecture documentation and contributor guidance.
+- Resume roadmap work in this order:
+  1. canonical stub generation and CI drift checking;
+  2. compatibility report and PocketPy patch verification artifacts;
+  3. cross-target build reliability;
+  4. tree-shaking/module selection for size;
+  5. `ucharm dev` watch mode;
+  6. remaining networking, format, concurrency, and database work;
+  7. higher-level TUI features from `vision.md`.
+
+## Suggested PR Sequence
+
+Keep changes reviewable and reversible:
+
+1. Decision, baseline scripts, and golden fixtures.
+2. Cargo workspace plus `pocketpy-sys` proof.
+3. Rust loader and cross-format tests.
+4. Rust CLI using existing assets.
+5. Runtime wrapper and declarative registrar.
+6. One PR per module wave, split further when a wave is too large.
+7. Four-target release candidate and workflow cutover.
+8. Zig removal and documentation cleanup.
+
+Do not mix unrelated product redesigns into these PRs. A migration regression
+should be attributable to one boundary or module group.
+
+## Principal Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Rust binaries exceed the size goal | Measure in Phase 1; use LTO, aborting panics, stripping, dependency review, and feature-gated heavy modules. |
+| C cross-compilation is harder without Zig | Prove all four targets in Phase 1 and prefer native-architecture CI runners. |
+| Unsafe PocketPy bindings introduce lifetime bugs | Confine raw FFI, document invariants, add sanitizer/leak jobs, and review the wrapper before module scaling. |
+| A long dual implementation stalls the roadmap | Freeze Zig features, port in vertical slices, and enforce exit gates rather than an open-ended rewrite branch. |
+| Behavioral parity drifts silently | Reuse CPython fixtures and add Zig/Rust differential output tests. |
+| Intel macOS support degrades | Keep an explicit x86_64 build and smoke-test job; document its support tier honestly. |
+| Universal binaries become incompatible | Freeze `MCHARM01` as v1 and test both old/new packager-loader directions. |
+
+## Definition of Done
+
+The migration is complete when stable releases of `ucharm`, the PocketPy
+runtime, and all loader stubs are built with stable Rust plus the vendored C
+sources; all current tests pass on all release targets; existing universal
+binaries remain runnable; startup and size budgets are met; and the CI/release
+path contains no Zig dependency.

--- a/runtime/compat/subprocess.zig
+++ b/runtime/compat/subprocess.zig
@@ -19,13 +19,111 @@ const PopenObj = struct {
 };
 
 const RunResult = struct {
-    stdout: []u8,
-    stderr: []u8,
+    stdout: []const u8,
+    stderr: []const u8,
     returncode: i64,
 };
 
-fn readAll(alloc: std.mem.Allocator, file: std.fs.File) []u8 {
-    return file.readToEndAlloc(alloc, 1024 * 1024) catch &[_]u8{};
+const max_output_bytes: usize = 1024 * 1024;
+
+fn appendCapped(alloc: std.mem.Allocator, buf: *std.ArrayList(u8), data: []const u8, cap: usize) void {
+    if (buf.items.len >= cap) return;
+    const space = cap - buf.items.len;
+    const to_copy = @min(space, data.len);
+    if (to_copy > 0) {
+        buf.appendSlice(alloc, data[0..to_copy]) catch {};
+    }
+}
+
+fn readAllCapped(alloc: std.mem.Allocator, file: std.fs.File, cap: usize) []const u8 {
+    var out = std.ArrayList(u8).empty;
+    defer out.deinit(alloc);
+
+    var tmp: [4096]u8 = undefined;
+    while (true) {
+        const n = file.read(&tmp) catch break;
+        if (n == 0) break;
+        appendCapped(alloc, &out, tmp[0..n], cap);
+    }
+    return out.toOwnedSlice(alloc) catch &[_]u8{};
+}
+
+fn setNonBlocking(fd: std.posix.fd_t) void {
+    const flags = std.posix.fcntl(fd, std.posix.F.GETFL, 0) catch return;
+    const nonblock = @as(usize, 1) << @bitOffsetOf(std.posix.O, "NONBLOCK");
+    _ = std.posix.fcntl(fd, std.posix.F.SETFL, flags | nonblock) catch {};
+}
+
+fn readPipedOutputs(
+    alloc: std.mem.Allocator,
+    stdout_file: ?std.fs.File,
+    stderr_file: ?std.fs.File,
+    cap: usize,
+) !struct { stdout: []const u8, stderr: []const u8 } {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        const out_bytes = if (stdout_file) |f| readAllCapped(alloc, f, cap) else &[_]u8{};
+        const err_bytes = if (stderr_file) |f| readAllCapped(alloc, f, cap) else &[_]u8{};
+        return .{ .stdout = out_bytes, .stderr = err_bytes };
+    }
+
+    var out = std.ArrayList(u8).empty;
+    var err = std.ArrayList(u8).empty;
+
+    var out_done = stdout_file == null;
+    var err_done = stderr_file == null;
+
+    const out_fd = if (stdout_file) |f| f.handle else -1;
+    const err_fd = if (stderr_file) |f| f.handle else -1;
+
+    if (!out_done) setNonBlocking(out_fd);
+    if (!err_done) setNonBlocking(err_fd);
+
+    var tmp: [4096]u8 = undefined;
+    while (!out_done or !err_done) {
+        var fds: [2]std.posix.pollfd = undefined;
+        var count: usize = 0;
+        if (!out_done) {
+            fds[count] = .{ .fd = out_fd, .events = std.posix.POLL.IN | std.posix.POLL.HUP, .revents = 0 };
+            count += 1;
+        }
+        if (!err_done) {
+            fds[count] = .{ .fd = err_fd, .events = std.posix.POLL.IN | std.posix.POLL.HUP, .revents = 0 };
+            count += 1;
+        }
+
+        _ = std.posix.poll(fds[0..count], -1) catch break;
+
+        var idx: usize = 0;
+        while (idx < count) : (idx += 1) {
+            if (fds[idx].revents & std.posix.POLL.IN == 0 and fds[idx].revents & std.posix.POLL.HUP == 0) continue;
+            const is_out = (!out_done and fds[idx].fd == out_fd);
+            const file = if (is_out) stdout_file.? else stderr_file.?;
+            if (fds[idx].revents & std.posix.POLL.HUP != 0 and fds[idx].revents & std.posix.POLL.IN == 0) {
+                if (is_out) out_done = true else err_done = true;
+                continue;
+            }
+            while (true) {
+                const n = file.read(&tmp) catch |err_read| {
+                    if (err_read == error.WouldBlock) break;
+                    if (is_out) out_done = true else err_done = true;
+                    break;
+                };
+                if (n == 0) {
+                    if (is_out) out_done = true else err_done = true;
+                    break;
+                }
+                if (is_out) {
+                    appendCapped(alloc, &out, tmp[0..n], cap);
+                } else {
+                    appendCapped(alloc, &err, tmp[0..n], cap);
+                }
+            }
+        }
+    }
+
+    const out_bytes = out.toOwnedSlice(alloc) catch &[_]u8{};
+    const err_bytes = err.toOwnedSlice(alloc) catch &[_]u8{};
+    return .{ .stdout = out_bytes, .stderr = err_bytes };
 }
 
 fn runChild(alloc: std.mem.Allocator, args: []const []const u8, capture: bool) !RunResult {
@@ -36,11 +134,12 @@ fn runChild(alloc: std.mem.Allocator, args: []const []const u8, capture: bool) !
 
     try child.spawn();
 
-    var stdout_bytes: []u8 = &[_]u8{};
-    var stderr_bytes: []u8 = &[_]u8{};
+    var stdout_bytes: []const u8 = &[_]u8{};
+    var stderr_bytes: []const u8 = &[_]u8{};
     if (capture) {
-        if (child.stdout) |file| stdout_bytes = readAll(alloc, file);
-        if (child.stderr) |file| stderr_bytes = readAll(alloc, file);
+        const outputs = try readPipedOutputs(alloc, child.stdout, child.stderr, max_output_bytes);
+        stdout_bytes = outputs.stdout;
+        stderr_bytes = outputs.stderr;
     }
 
     const term = try child.wait();
@@ -52,17 +151,28 @@ fn runChild(alloc: std.mem.Allocator, args: []const []const u8, capture: bool) !
     return .{ .stdout = stdout_bytes, .stderr = stderr_bytes, .returncode = returncode };
 }
 
-fn buildArgvFromList(alloc: std.mem.Allocator, list: c.py_Ref, out: *std.ArrayList([]const u8)) bool {
-    if (!c.py_checktype(list, c.tp_list)) return false;
-    const list_len = c.py_list_len(list);
-    if (list_len <= 0) return c.py_exception(c.tp_TypeError, "args must be a non-empty list");
+fn buildArgvFromSeq(alloc: std.mem.Allocator, seq: c.py_Ref, out: *std.ArrayList([]const u8)) bool {
+    const len: c_int = if (c.py_islist(seq)) c.py_list_len(seq) else c.py_tuple_len(seq);
+    if (len <= 0) return c.py_exception(c.tp_TypeError, "args must be a non-empty sequence");
     var i: c_int = 0;
-    while (i < list_len) : (i += 1) {
-        const item = c.py_list_getitem(list, i);
+    while (i < len) : (i += 1) {
+        const item = if (c.py_islist(seq)) c.py_list_getitem(seq, i) else c.py_tuple_getitem(seq, i);
         const cstr = c.py_tostr(item) orelse return c.py_exception(c.tp_TypeError, "args must be strings");
         out.append(alloc, std.mem.span(cstr)) catch return c.py_exception(c.tp_RuntimeError, "out of memory");
     }
     return true;
+}
+
+fn buildArgvFromArgs(alloc: std.mem.Allocator, args_val: c.py_Ref, out: *std.ArrayList([]const u8)) bool {
+    if (c.py_isstr(args_val)) {
+        const cstr = c.py_tostr(args_val) orelse return c.py_exception(c.tp_TypeError, "args must be a string");
+        out.append(alloc, std.mem.span(cstr)) catch return c.py_exception(c.tp_RuntimeError, "out of memory");
+        return true;
+    }
+    if (c.py_islist(args_val) or c.py_istuple(args_val)) {
+        return buildArgvFromSeq(alloc, args_val, out);
+    }
+    return c.py_exception(c.tp_TypeError, "args must be a string or sequence");
 }
 
 fn run(argc: c_int, argv: c.py_StackRef) callconv(.c) bool {
@@ -87,7 +197,7 @@ fn run(argc: c_int, argv: c.py_StackRef) callconv(.c) bool {
         argv_list.append(alloc, "-c") catch return c.py_exception(c.tp_RuntimeError, "out of memory");
         argv_list.append(alloc, std.mem.span(cmd_c)) catch return c.py_exception(c.tp_RuntimeError, "out of memory");
     } else {
-        if (!buildArgvFromList(alloc, args_val, &argv_list)) return false;
+        if (!buildArgvFromArgs(alloc, args_val, &argv_list)) return false;
     }
 
     const result = runChild(alloc, argv_list.items, capture_output) catch return c.py_exception(c.tp_RuntimeError, "failed to run process");
@@ -124,9 +234,9 @@ fn callFn(argc: c_int, argv: c.py_StackRef) callconv(.c) bool {
     // call(args) is run(args).returncode
     if (!run(1, argv)) return false;
     const dict = c.py_retval();
-    const rc = c.py_dict_getitem_by_str(dict, subprocess_returncode_key);
-    if (rc <= 0) return c.py_exception(c.tp_RuntimeError, "returncode missing");
-    pk.setRetval(c.py_retval());
+    if (c.py_dict_getitem_by_str(dict, subprocess_returncode_key) == 0) {
+        return c.py_exception(c.tp_RuntimeError, "returncode missing");
+    }
     return true;
 }
 
@@ -138,9 +248,12 @@ fn check_outputFn(argc: c_int, argv: c.py_StackRef) callconv(.c) bool {
 
     var argv_list: std.ArrayList([]const u8) = .empty;
     defer argv_list.deinit(alloc);
-    if (!buildArgvFromList(alloc, pk.argRef(argv, 0), &argv_list)) return false;
+    if (!buildArgvFromArgs(alloc, pk.argRef(argv, 0), &argv_list)) return false;
 
     const result = runChild(alloc, argv_list.items, true) catch return c.py_exception(c.tp_RuntimeError, "failed to run process");
+    if (result.returncode != 0) {
+        return c.py_exception(c.tp_RuntimeError, "process returned non-zero exit status");
+    }
     // Return a string to avoid relying on bytes.decode(encoding) support in PocketPy.
     const out_buf = c.py_newstrn(c.py_retval(), @intCast(result.stdout.len));
     if (result.stdout.len > 0) {
@@ -252,7 +365,7 @@ fn popenInit(argc: c_int, argv: c.py_StackRef) callconv(.c) bool {
         argv_list.append(alloc, "-c") catch return c.py_exception(c.tp_RuntimeError, "out of memory");
         argv_list.append(alloc, std.mem.span(cmd_c)) catch return c.py_exception(c.tp_RuntimeError, "out of memory");
     } else {
-        if (!buildArgvFromList(alloc, args_val, &argv_list)) return false;
+        if (!buildArgvFromArgs(alloc, args_val, &argv_list)) return false;
     }
 
     const ud = getPopen(self) orelse return c.py_exception(c.tp_RuntimeError, "invalid Popen");
@@ -293,11 +406,14 @@ fn popenCommunicate(argc: c_int, argv: c.py_StackRef) callconv(.c) bool {
     const ud = getPopen(self) orelse return c.py_exception(c.tp_RuntimeError, "invalid Popen");
     if (!ud.started) return c.py_exception(c.tp_RuntimeError, "process not started");
 
-    var out_bytes: []u8 = &[_]u8{};
-    var err_bytes: []u8 = &[_]u8{};
+    var out_bytes: []const u8 = &[_]u8{};
+    var err_bytes: []const u8 = &[_]u8{};
 
-    if (ud.child.stdout) |file| out_bytes = readAll(std.heap.c_allocator, file);
-    if (ud.child.stderr) |file| err_bytes = readAll(std.heap.c_allocator, file);
+    if (ud.child.stdout != null or ud.child.stderr != null) {
+        const outputs = readPipedOutputs(std.heap.c_allocator, ud.child.stdout, ud.child.stderr, max_output_bytes) catch return c.py_exception(c.tp_RuntimeError, "failed to read output");
+        out_bytes = outputs.stdout;
+        err_bytes = outputs.stderr;
+    }
 
     const term = ud.child.wait() catch return c.py_exception(c.tp_RuntimeError, "wait failed");
     var returncode: i64 = -1;

--- a/tests/compat_report_pocketpy.md
+++ b/tests/compat_report_pocketpy.md
@@ -1,12 +1,12 @@
 # μcharm Compatibility Report
 
-Generated: 2025-12-21 03:06:57
+Generated: 2026-08-04 10:01:48
 
 ## Summary
 
 ### Targeted Modules
 
-- **Tests passing**: 1,663/1,663 (100.0%)
+- **Tests passing**: 1,668/1,668 (100.0%)
 - **Modules at 100%**: 51/52
 - **Modules partial**: 0/52
 - **No baseline (host CPython)**: 1/52
@@ -58,7 +58,7 @@ Generated: 2025-12-21 03:06:57
 | sqlite3 | stdlib | 2/2 | 2/2 | 100% | ✅ Full |
 | statistics | stdlib | 28/28 | 28/28 | 100% | ✅ Full |
 | struct | stdlib | 68/68 | 68/68 | 100% | ✅ Full |
-| subprocess | stdlib | 14/14 | 14/14 | 100% | ✅ Full |
+| subprocess | stdlib | 19/19 | 19/19 | 100% | ✅ Full |
 | sys | stdlib | 58/58 | 58/58 | 100% | ✅ Full |
 | tarfile | stdlib | 7/7 | 7/7 | 100% | ✅ Full |
 | tempfile | stdlib | 9/9 | 9/9 | 100% | ✅ Full |

--- a/tests/cpython/test_subprocess.py
+++ b/tests/cpython/test_subprocess.py
@@ -50,6 +50,16 @@ def get_returncode(result):
     return result.returncode
 
 
+def get_stderr(result):
+    if isinstance(result, dict):
+        raw = result.get("stderr", "")
+    else:
+        raw = result.stderr
+    if isinstance(raw, bytes):
+        return raw.decode()
+    return raw or ""
+
+
 # ============================================================================
 # subprocess.run() tests
 # ============================================================================
@@ -60,11 +70,22 @@ result = subprocess.run(["echo", "hello"], capture_output=True)
 test("run echo hello - returncode", get_returncode(result) == 0)
 test("run echo hello - stdout", get_stdout(result) == "hello")
 
+result = subprocess.run(["echo", "hello world"], capture_output=True)
+test("run echo hello world - stdout preserves space", get_stdout(result) == "hello world")
+
 result = subprocess.run(["true"], capture_output=True)
 test("run true - zero returncode", get_returncode(result) == 0)
 
 result = subprocess.run(["false"], capture_output=True)
 test("run false - non-zero returncode", get_returncode(result) != 0)
+
+# Both pipes must be drained concurrently or one full pipe can deadlock the child.
+result = subprocess.run(
+    ["sh", "-c", "(yes o | head -c 70000) & (yes e | head -c 70000 >&2) & wait"],
+    capture_output=True,
+)
+test("run drains large stdout", len(get_stdout(result)) >= 69999)
+test("run drains large stderr", len(get_stderr(result)) >= 69999)
 
 
 # ============================================================================
@@ -85,6 +106,8 @@ if _shell_supported:
     result = subprocess.run("echo hello", capture_output=True, shell=True)
     test("run shell echo - returncode", get_returncode(result) == 0)
     test("run shell echo - stdout", get_stdout(result) == "hello")
+    result = subprocess.run("printf '%s' \"hello world\"", capture_output=True, shell=True)
+    test("run shell printf - stdout preserves space", get_stdout(result) == "hello world")
 else:
     skip("run shell echo - returncode", "shell=True not supported")
     skip("run shell echo - stdout", "shell=True not supported")
@@ -118,6 +141,11 @@ if hasattr(subprocess, "check_output"):
     if isinstance(output, bytes):
         output = output.decode("utf-8")
     test("check_output echo", output.strip() == "hello")
+    try:
+        subprocess.check_output(["false"])
+        test("check_output non-zero raises", False)
+    except Exception:
+        test("check_output non-zero raises", True)
 else:
     skip("check_output echo", "subprocess.check_output not available")
 


### PR DESCRIPTION
## What changed

- records the decision and phased plan to migrate the native implementation from Zig to stable Rust while retaining PocketPy
- defines the target Cargo workspace, FFI boundaries, compatibility gates, cross-target strategy, module waves, and roadmap continuation
- fixes subprocess stdout/stderr pipe deadlocks by draining both streams concurrently
- preserves argv spacing, accepts sequence arguments, fixes `check_output()` failure behavior, and expands subprocess regression coverage
- refreshes the compatibility report and ignores Zig package cache output

## Why

The project has over 28,000 lines coupled to pre-1.0 Zig APIs, and the pinned Zig 0.15.2 code already fails against stable Zig 0.16.0. Rust offers a stable host-language contract while preserving PocketPy, the current Python API, and the universal binary format.

The subprocess changes were already present locally but did not compile cleanly and included an invalid return-value operation that caused a segmentation fault. This branch corrects and validates that work before publishing it.

## Impact

There is no product cutover in this PR. Zig remains the current implementation while Rust migration phases proceed behind explicit parity, size, startup, and target gates. The subprocess behavior is more CPython-compatible and avoids deadlocks when both output pipes fill.

## Validation

- PocketPy vendor patch verification
- Zig format checks for runtime, PocketPy, CLI, and loader
- 1,668/1,668 compatibility tests
- 28/28 CLI end-to-end tests
- CLI unit tests and release builds
- PocketPy release builds for native macOS, macOS x86_64, Linux x86_64 musl, and Linux ARM64 musl
- loader release build and CLI version smoke test