### PR TITLE
Add the Rust CLI foundation and project commands

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,9 @@ jobs:
         run: >-
           target/${{ matrix.target }}/release/pocketpy-ucharm-rs
           -c 'import _ucharm_rust; assert _ucharm_rust.answer() == 42'
+      - name: Smoke-test Rust CLI
+        shell: bash
+        run: target/${{ matrix.target }}/release/ucharm-rs --version | grep -q "μcharm"
       - name: Smoke-test bare loader diagnostics
         shell: bash
         run: |
@@ -72,4 +75,9 @@ jobs:
           loader_size = loader.stat().st_size
           print(f"{loader}: {loader_size:,} bytes")
           assert loader_size < 1_000_000, f"Rust loader exceeds 1 MB: {loader_size:,} bytes"
+
+          cli = Path("target/${{ matrix.target }}/release/ucharm-rs")
+          cli_size = cli.stat().st_size
+          print(f"{cli}: {cli_size:,} bytes")
+          assert cli_size < 1_500_000, f"Rust CLI exceeds 1.5 MB: {cli_size:,} bytes"
           PY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucharm-cli"
+version = "0.5.0"
+
+[[package]]
 name = "ucharm-format"
 version = "0.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/pocketpy-sys",
+    "crates/ucharm-cli",
     "crates/ucharm-format",
     "crates/ucharm-loader",
     "crates/ucharm-runtime",

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -149,10 +149,17 @@ status, stdout, and stderr.
 - Phase 1 is in progress: the Cargo workspace builds vendored PocketPy through
   `pocketpy-sys`, a Rust-owned VM executes Python, and a probe native module
   crosses the C callback boundary.
-- Phase 2 is in progress: `ucharm-format` encodes and decodes the exact
-  `MCHARM01` wire format, and the Rust loader validates, atomically extracts,
-  caches, and executes Zig-packaged payloads. Zig and Rust share byte-level
-  trailer and cache-hash vectors.
+- Phase 2 is functionally complete: `ucharm-format` encodes and decodes the
+  exact `MCHARM01` wire format, and the Rust loader validates, atomically
+  extracts, caches, and executes Zig-packaged payloads. Zig and Rust share
+  byte-level trailer and cache-hash vectors. The measured Rust loader adds
+  9.2% to a universal application while slightly improving warm startup; the
+  accepted size variance is recorded in `benchmarks/loader_migration_baseline.md`.
+- Phase 3 is in progress: the dependency-free `ucharm-cli` crate has the
+  production command dispatcher plus `new` and `init`. Valid command output,
+  generated files, file modes, embedded stubs, and assistant instructions have
+  byte-for-byte parity with the Zig CLI. `run`, `build`, and `test` remain
+  explicitly delegated to the production Zig CLI until their ports land.
 - The initial stripped macOS ARM64 Rust spine is about 600 KB before μcharm's
   native modules and external C dependencies are added. This is an early
   feasibility signal, not a final size comparison.

--- a/crates/ucharm-cli/Cargo.toml
+++ b/crates/ucharm-cli/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ucharm-cli"
+description = "Command-line interface for μcharm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "ucharm-rs"
+path = "src/main.rs"
+
+[lints]
+workspace = true

--- a/crates/ucharm-cli/src/lib.rs
+++ b/crates/ucharm-cli/src/lib.rs
@@ -1,0 +1,412 @@
+mod project;
+
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+
+use project::{AiInstructions, ProjectOptions};
+
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const RED: &str = "\x1b[31m";
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const CYAN: &str = "\x1b[36m";
+
+#[must_use]
+pub fn version() -> &'static str {
+    include_str!("../../../VERSION").trim()
+}
+
+pub fn run(
+    arguments: &[String],
+    current_directory: &Path,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> io::Result<u8> {
+    let Some(command) = arguments.first().map(String::as_str) else {
+        print_logo(stdout)?;
+        write!(stdout, "{}", main_help())?;
+        return Ok(0);
+    };
+
+    match command {
+        "-h" | "--help" => {
+            print_logo(stdout)?;
+            write!(stdout, "{}", main_help())?;
+            Ok(0)
+        }
+        "-v" | "--version" => {
+            writeln!(
+                stdout,
+                "{CYAN}{BOLD}μcharm{RESET} {DIM}v{}{RESET}",
+                version()
+            )?;
+            Ok(0)
+        }
+        "new" => run_new(&arguments[1..], current_directory, stdout, stderr),
+        "init" => run_init(&arguments[1..], current_directory, stdout, stderr),
+        "build" | "run" | "test" => {
+            writeln!(
+                stderr,
+                "{RED}Error:{RESET} Command '{BOLD}{command}{RESET}' has not migrated to Rust yet"
+            )?;
+            writeln!(
+                stderr,
+                "{DIM}Use the production Zig CLI for this command during the migration.{RESET}"
+            )?;
+            Ok(1)
+        }
+        unknown => {
+            writeln!(
+                stderr,
+                "{RED}Error:{RESET} Unknown command '{BOLD}{unknown}{RESET}'"
+            )?;
+            writeln!(
+                stderr,
+                "{DIM}Run '{RESET}ucharm --help{DIM}' for usage.{RESET}"
+            )?;
+            Ok(1)
+        }
+    }
+}
+
+fn run_new(
+    arguments: &[String],
+    current_directory: &Path,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> io::Result<u8> {
+    let mut options = ProjectOptions {
+        create_app: true,
+        ..ProjectOptions::default()
+    };
+    let mut name = None;
+    let mut minimal = false;
+    let mut index = 0;
+
+    while index < arguments.len() {
+        match arguments[index].as_str() {
+            "-h" | "--help" => {
+                write!(stdout, "{}", new_help())?;
+                return Ok(0);
+            }
+            "--stubs" => options.add_stubs = true,
+            "--all" => {
+                options.add_stubs = true;
+                options.ai = Some(AiInstructions::All);
+            }
+            "--minimal" => minimal = true,
+            "--ai" => {
+                index += 1;
+                let Some(value) = arguments.get(index) else {
+                    return usage_error(
+                        stderr,
+                        "--ai requires a type (agents, claude, copilot, all)",
+                    );
+                };
+                options.ai = match AiInstructions::parse(value) {
+                    Some(ai) => Some(ai),
+                    None => {
+                        return usage_error(
+                            stderr,
+                            "invalid --ai type; use agents, claude, copilot, or all",
+                        );
+                    }
+                };
+            }
+            option if option.starts_with('-') => {
+                return usage_error(stderr, &format!("unknown option '{option}'"));
+            }
+            value if name.is_none() => name = Some(value.to_owned()),
+            value => return usage_error(stderr, &format!("unexpected argument '{value}'")),
+        }
+        index += 1;
+    }
+
+    let Some(name) = name else {
+        writeln!(stderr, "{RED}Error:{RESET} No project name specified")?;
+        writeln!(stderr, "{DIM}Usage: {RESET}ucharm new <name>")?;
+        return Ok(1);
+    };
+    let sanitized = match project::sanitize_name(&name) {
+        Ok(name) => name,
+        Err(message) => return usage_error(stderr, message),
+    };
+    options.app_name = Some(name.clone());
+
+    print_new_logo(stdout)?;
+    writeln!(stdout, "Creating new project: {BOLD}{name}{RESET}\n")?;
+
+    if minimal {
+        project::initialize(current_directory, &options, stdout)?;
+        return Ok(0);
+    }
+
+    let project_directory = current_directory.join(&sanitized);
+    match fs::create_dir(&project_directory) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            writeln!(
+                stderr,
+                "{RED}Error:{RESET} Directory '{sanitized}' already exists"
+            )?;
+            return Ok(1);
+        }
+        Err(error) => return Err(with_context(error, "failed to create project directory")),
+    }
+    writeln!(stdout, "{GREEN}+{RESET} Created {sanitized}/")?;
+    project::initialize(&project_directory, &options, stdout)?;
+
+    writeln!(stdout, "\n\x1b[32mDone!{RESET} Project created.\n")?;
+    write!(stdout, "{BOLD}Next steps:\n{RESET}")?;
+    writeln!(stdout, "  {DIM}${RESET} {CYAN}cd {sanitized}{RESET}")?;
+    writeln!(
+        stdout,
+        "  {DIM}${RESET} {CYAN}ucharm run {sanitized}.py{RESET}\n"
+    )?;
+    write!(stdout, "{BOLD}Build standalone binary:\n{RESET}")?;
+    writeln!(
+        stdout,
+        "  {DIM}${RESET} {CYAN}ucharm build {sanitized}.py -o {sanitized} --mode universal{RESET}"
+    )?;
+    Ok(0)
+}
+
+fn run_init(
+    arguments: &[String],
+    current_directory: &Path,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> io::Result<u8> {
+    let mut options = ProjectOptions::default();
+    let mut index = 0;
+
+    while index < arguments.len() {
+        match arguments[index].as_str() {
+            "-h" | "--help" => {
+                write!(stdout, "{}", init_help())?;
+                return Ok(0);
+            }
+            "--stubs" => options.add_stubs = true,
+            "--all" => {
+                options.add_stubs = true;
+                options.ai = Some(AiInstructions::All);
+            }
+            "--ai" => {
+                index += 1;
+                let Some(value) = arguments.get(index) else {
+                    return usage_error(
+                        stderr,
+                        "--ai requires a type (agents, claude, copilot, all)",
+                    );
+                };
+                options.ai = match AiInstructions::parse(value) {
+                    Some(ai) => Some(ai),
+                    None => {
+                        return usage_error(
+                            stderr,
+                            "invalid --ai type; use agents, claude, copilot, or all",
+                        );
+                    }
+                };
+            }
+            option => return usage_error(stderr, &format!("unknown option '{option}'")),
+        }
+        index += 1;
+    }
+
+    if !options.add_stubs && options.ai.is_none() {
+        writeln!(
+            stdout,
+            "{YELLOW}No options specified.{RESET} Use --stubs, --ai, or --all\n"
+        )?;
+        write!(stdout, "{}", init_help())?;
+        return Ok(0);
+    }
+
+    let files_created = project::initialize(current_directory, &options, stdout)?;
+    writeln!(
+        stdout,
+        "\n\x1b[32mDone!{RESET} Initialized ucharm in current directory."
+    )?;
+    if options.add_stubs && files_created > 0 {
+        writeln!(
+            stdout,
+            "\n{DIM}IDE autocomplete should now work for ucharm modules.{RESET}"
+        )?;
+    }
+    Ok(0)
+}
+
+fn usage_error(stderr: &mut dyn Write, message: &str) -> io::Result<u8> {
+    writeln!(stderr, "{RED}Error:{RESET} {message}")?;
+    Ok(1)
+}
+
+fn with_context(error: io::Error, context: &str) -> io::Error {
+    io::Error::new(error.kind(), format!("{context}: {error}"))
+}
+
+fn print_logo(output: &mut dyn Write) -> io::Result<()> {
+    let tagline = "Beautiful CLIs with PocketPy";
+    let box_width = tagline.len() + 6;
+    let title_width = 8 + version().len();
+    let title_pad_left = (box_width - title_width) / 2;
+    let title_pad_right = box_width - title_width - title_pad_left;
+    let tagline_pad_left = (box_width - tagline.len()) / 2;
+    let tagline_pad_right = box_width - tagline.len() - tagline_pad_left;
+
+    writeln!(output)?;
+    write!(output, "{CYAN}{BOLD}  ╭{}╮\n{RESET}", "─".repeat(box_width))?;
+    write!(
+        output,
+        "{CYAN}{BOLD}  │{RESET}{}{CYAN}{BOLD}μcharm{RESET} {DIM}v{}{RESET}{}{CYAN}{BOLD}│\n{RESET}",
+        " ".repeat(title_pad_left),
+        version(),
+        " ".repeat(title_pad_right)
+    )?;
+    write!(
+        output,
+        "{CYAN}{BOLD}  │{RESET}{}{DIM}{tagline}{RESET}{}{CYAN}{BOLD}│\n{RESET}",
+        " ".repeat(tagline_pad_left),
+        " ".repeat(tagline_pad_right)
+    )?;
+    write!(output, "{CYAN}{BOLD}  ╰{}╯\n{RESET}", "─".repeat(box_width))?;
+    writeln!(output)
+}
+
+fn print_new_logo(output: &mut dyn Write) -> io::Result<()> {
+    writeln!(
+        output,
+        "\n{CYAN}┌┬┐┌─┐┬ ┬┌─┐┬─┐┌┬┐{RESET}\n{CYAN}││││  ├─┤├─┤├┬┘│││{RESET}\n{CYAN}┴ ┴└─┘┴ ┴┴ ┴┴└─┴ ┴{RESET}"
+    )?;
+    writeln!(output, "{DIM}Beautiful CLIs with PocketPy{RESET}\n")
+}
+
+fn main_help() -> String {
+    format!(
+        "{BOLD}USAGE{RESET}\n    ucharm {CYAN}<command>{RESET} [options]\n\n{BOLD}COMMANDS{RESET}\n    {CYAN}new{RESET} {DIM}<name>{RESET}        Create a new project\n    {CYAN}run{RESET} {DIM}<file>{RESET}        Run a script with pocketpy\n    {CYAN}build{RESET} {DIM}<file>{RESET}      Build a standalone binary\n    {CYAN}init{RESET}              Initialize ucharm in current directory\n    {CYAN}test{RESET}              Run compatibility tests\n\n{BOLD}OPTIONS{RESET}\n    {CYAN}-h{RESET}, {CYAN}--help{RESET}        Show this help\n    {CYAN}-v{RESET}, {CYAN}--version{RESET}     Show version\n\n{BOLD}EXAMPLES{RESET}\n    {DIM}${RESET} ucharm new myapp                  {DIM}# Create new project{RESET}\n    {DIM}${RESET} ucharm run app.py                 {DIM}# Run with pocketpy{RESET}\n    {DIM}${RESET} ucharm build app.py -o app        {DIM}# Build universal binary{RESET}\n    {DIM}${RESET} ucharm init --stubs --ai claude   {DIM}# Add IDE support{RESET}\n\n{DIM}    Docs: https://github.com/ucharmdev/ucharm{RESET}\n"
+    )
+}
+
+fn new_help() -> String {
+    format!(
+        "{BOLD}ucharm new{RESET} - Create a new ucharm project\n\n{DIM}USAGE:{RESET}\n    ucharm new <name> [options]\n\n{DIM}ARGUMENTS:{RESET}\n    <name>           Project name (creates <name>/ directory)\n\n{DIM}OPTIONS:{RESET}\n    --stubs          Add type stubs for IDE autocomplete\n    --ai <type>      Add AI assistant instructions\n                     Types: agents, claude, copilot, all\n    --all            Add stubs and AI instructions (agents + claude)\n    --minimal        Just create the .py file (no directory)\n    -h, --help       Show this help\n\n{DIM}EXAMPLES:{RESET}\n    ucharm new myapp\n    ucharm new myapp --all\n    ucharm new myapp --stubs --ai claude\n    ucharm new myapp --minimal\n\n{DIM}FILES CREATED:{RESET}\n    myapp/\n      myapp.py                       Main application file\n      .ucharm/stubs/                 Type stubs (with --stubs)\n      pyrightconfig.json             Pyright config (with --stubs)\n      AGENTS.md                      AI instructions (with --ai)\n"
+    )
+}
+
+fn init_help() -> String {
+    format!(
+        "{BOLD}ucharm init{RESET} - Initialize ucharm in current directory\n\n{DIM}USAGE:{RESET}\n    ucharm init [options]\n\n{DIM}OPTIONS:{RESET}\n    --stubs          Add type stubs for IDE autocomplete\n    --ai <type>      Add AI assistant instructions\n                     Types: agents, claude, copilot, all\n    --all            Add both stubs and AI instructions (agents + claude)\n    -h, --help       Show this help\n\n{DIM}EXAMPLES:{RESET}\n    ucharm init --stubs\n    ucharm init --ai agents\n    ucharm init --all\n\n{DIM}FILES CREATED:{RESET}\n    .ucharm/stubs/                   Type stubs for runtime modules\n    pyrightconfig.json               Pyright configuration\n    AGENTS.md                        Universal (Cursor, Windsurf, Zed)\n    CLAUDE.md                        Claude Code\n    .github/copilot-instructions.md  GitHub Copilot\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{init_help, main_help, new_help, project::sanitize_name};
+
+    #[test]
+    fn help_text_matches_the_zig_cli_snapshots() {
+        assert_eq!(
+            main_help(),
+            concat!(
+                "\x1b[1mUSAGE\x1b[0m\n",
+                "    ucharm \x1b[36m<command>\x1b[0m [options]\n\n",
+                "\x1b[1mCOMMANDS\x1b[0m\n",
+                "    \x1b[36mnew\x1b[0m \x1b[2m<name>\x1b[0m        Create a new project\n",
+                "    \x1b[36mrun\x1b[0m \x1b[2m<file>\x1b[0m        Run a script with pocketpy\n",
+                "    \x1b[36mbuild\x1b[0m \x1b[2m<file>\x1b[0m      Build a standalone binary\n",
+                "    \x1b[36minit\x1b[0m              Initialize ucharm in current directory\n",
+                "    \x1b[36mtest\x1b[0m              Run compatibility tests\n\n",
+                "\x1b[1mOPTIONS\x1b[0m\n",
+                "    \x1b[36m-h\x1b[0m, \x1b[36m--help\x1b[0m        Show this help\n",
+                "    \x1b[36m-v\x1b[0m, \x1b[36m--version\x1b[0m     Show version\n\n",
+                "\x1b[1mEXAMPLES\x1b[0m\n",
+                "    \x1b[2m$\x1b[0m ucharm new myapp                  \x1b[2m# Create new project\x1b[0m\n",
+                "    \x1b[2m$\x1b[0m ucharm run app.py                 \x1b[2m# Run with pocketpy\x1b[0m\n",
+                "    \x1b[2m$\x1b[0m ucharm build app.py -o app        \x1b[2m# Build universal binary\x1b[0m\n",
+                "    \x1b[2m$\x1b[0m ucharm init --stubs --ai claude   \x1b[2m# Add IDE support\x1b[0m\n\n",
+                "\x1b[2m    Docs: https://github.com/ucharmdev/ucharm\x1b[0m\n",
+            )
+        );
+        assert_eq!(
+            new_help(),
+            concat!(
+                "\x1b[1mucharm new\x1b[0m - Create a new ucharm project\n\n",
+                "\x1b[2mUSAGE:\x1b[0m\n    ucharm new <name> [options]\n\n",
+                "\x1b[2mARGUMENTS:\x1b[0m\n",
+                "    <name>           Project name (creates <name>/ directory)\n\n",
+                "\x1b[2mOPTIONS:\x1b[0m\n",
+                "    --stubs          Add type stubs for IDE autocomplete\n",
+                "    --ai <type>      Add AI assistant instructions\n",
+                "                     Types: agents, claude, copilot, all\n",
+                "    --all            Add stubs and AI instructions (agents + claude)\n",
+                "    --minimal        Just create the .py file (no directory)\n",
+                "    -h, --help       Show this help\n\n",
+                "\x1b[2mEXAMPLES:\x1b[0m\n",
+                "    ucharm new myapp\n",
+                "    ucharm new myapp --all\n",
+                "    ucharm new myapp --stubs --ai claude\n",
+                "    ucharm new myapp --minimal\n\n",
+                "\x1b[2mFILES CREATED:\x1b[0m\n",
+                "    myapp/\n",
+                "      myapp.py                       Main application file\n",
+                "      .ucharm/stubs/                 Type stubs (with --stubs)\n",
+                "      pyrightconfig.json             Pyright config (with --stubs)\n",
+                "      AGENTS.md                      AI instructions (with --ai)\n",
+            )
+        );
+        assert_eq!(
+            init_help(),
+            concat!(
+                "\x1b[1mucharm init\x1b[0m - Initialize ucharm in current directory\n\n",
+                "\x1b[2mUSAGE:\x1b[0m\n    ucharm init [options]\n\n",
+                "\x1b[2mOPTIONS:\x1b[0m\n",
+                "    --stubs          Add type stubs for IDE autocomplete\n",
+                "    --ai <type>      Add AI assistant instructions\n",
+                "                     Types: agents, claude, copilot, all\n",
+                "    --all            Add both stubs and AI instructions (agents + claude)\n",
+                "    -h, --help       Show this help\n\n",
+                "\x1b[2mEXAMPLES:\x1b[0m\n",
+                "    ucharm init --stubs\n",
+                "    ucharm init --ai agents\n",
+                "    ucharm init --all\n\n",
+                "\x1b[2mFILES CREATED:\x1b[0m\n",
+                "    .ucharm/stubs/                   Type stubs for runtime modules\n",
+                "    pyrightconfig.json               Pyright configuration\n",
+                "    AGENTS.md                        Universal (Cursor, Windsurf, Zed)\n",
+                "    CLAUDE.md                        Claude Code\n",
+                "    .github/copilot-instructions.md  GitHub Copilot\n",
+            )
+        );
+    }
+
+    #[test]
+    fn project_name_sanitization_matches_the_zig_cli() {
+        for (input, expected) in [
+            ("My App", "my_app"),
+            ("hello-world", "hello_world"),
+            ("TEST", "test"),
+            ("Simple", "simple"),
+        ] {
+            assert_eq!(sanitize_name(input), Ok(expected.to_owned()));
+        }
+    }
+
+    #[test]
+    fn project_names_cannot_escape_the_target_directory() {
+        for invalid in [
+            "",
+            ".",
+            "..",
+            "../app",
+            "path/app",
+            "path\\app",
+            "bad\0name",
+        ] {
+            assert!(sanitize_name(invalid).is_err(), "accepted {invalid:?}");
+        }
+    }
+}

--- a/crates/ucharm-cli/src/main.rs
+++ b/crates/ucharm-cli/src/main.rs
@@ -1,0 +1,44 @@
+use std::env;
+use std::io;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let arguments = match env::args_os()
+        .skip(1)
+        .map(|argument| {
+            argument
+                .into_string()
+                .map_err(|_| "arguments must be valid UTF-8")
+        })
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(arguments) => arguments,
+        Err(message) => {
+            eprintln!("error: {message}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let current_directory = match env::current_dir() {
+        Ok(directory) => directory,
+        Err(error) => {
+            eprintln!("error: cannot determine current directory: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let stdout = io::stdout();
+    let stderr = io::stderr();
+    match ucharm_cli::run(
+        &arguments,
+        &current_directory,
+        &mut stdout.lock(),
+        &mut stderr.lock(),
+    ) {
+        Ok(0) => ExitCode::SUCCESS,
+        Ok(code) => ExitCode::from(code),
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/ucharm-cli/src/project.rs
+++ b/crates/ucharm-cli/src/project.rs
@@ -1,0 +1,294 @@
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+const RESET: &str = "\x1b[0m";
+const DIM: &str = "\x1b[2m";
+const GREEN: &str = "\x1b[32m";
+
+const STUBS: &[(&str, &str)] = &[
+    ("ansi.pyi", include_str!("../../../cli/src/stubs/ansi.pyi")),
+    ("args.pyi", include_str!("../../../cli/src/stubs/args.pyi")),
+    (
+        "base64.pyi",
+        include_str!("../../../cli/src/stubs/base64.pyi"),
+    ),
+    (
+        "charm.pyi",
+        include_str!("../../../cli/src/stubs/charm.pyi"),
+    ),
+    ("copy.pyi", include_str!("../../../cli/src/stubs/copy.pyi")),
+    ("csv.pyi", include_str!("../../../cli/src/stubs/csv.pyi")),
+    (
+        "datetime.pyi",
+        include_str!("../../../cli/src/stubs/datetime.pyi"),
+    ),
+    (
+        "fnmatch.pyi",
+        include_str!("../../../cli/src/stubs/fnmatch.pyi"),
+    ),
+    (
+        "functools.pyi",
+        include_str!("../../../cli/src/stubs/functools.pyi"),
+    ),
+    ("glob.pyi", include_str!("../../../cli/src/stubs/glob.pyi")),
+    (
+        "heapq.pyi",
+        include_str!("../../../cli/src/stubs/heapq.pyi"),
+    ),
+    (
+        "input.pyi",
+        include_str!("../../../cli/src/stubs/input.pyi"),
+    ),
+    (
+        "itertools.pyi",
+        include_str!("../../../cli/src/stubs/itertools.pyi"),
+    ),
+    (
+        "logging.pyi",
+        include_str!("../../../cli/src/stubs/logging.pyi"),
+    ),
+    (
+        "operator.pyi",
+        include_str!("../../../cli/src/stubs/operator.pyi"),
+    ),
+    (
+        "random.pyi",
+        include_str!("../../../cli/src/stubs/random.pyi"),
+    ),
+    (
+        "shutil.pyi",
+        include_str!("../../../cli/src/stubs/shutil.pyi"),
+    ),
+    (
+        "signal.pyi",
+        include_str!("../../../cli/src/stubs/signal.pyi"),
+    ),
+    (
+        "statistics.pyi",
+        include_str!("../../../cli/src/stubs/statistics.pyi"),
+    ),
+    (
+        "subprocess.pyi",
+        include_str!("../../../cli/src/stubs/subprocess.pyi"),
+    ),
+    (
+        "tempfile.pyi",
+        include_str!("../../../cli/src/stubs/tempfile.pyi"),
+    ),
+    ("term.pyi", include_str!("../../../cli/src/stubs/term.pyi")),
+    (
+        "textwrap.pyi",
+        include_str!("../../../cli/src/stubs/textwrap.pyi"),
+    ),
+    (
+        "typing.pyi",
+        include_str!("../../../cli/src/stubs/typing.pyi"),
+    ),
+];
+
+const PYRIGHT_CONFIG: &str = r#"{
+  "include": ["."],
+  "exclude": [".ucharm"],
+  "stubPath": ".ucharm/stubs",
+  "reportMissingImports": false,
+  "reportMissingModuleSource": false,
+  "pythonVersion": "3.11",
+  "typeCheckingMode": "basic"
+}
+"#;
+
+const APP_TEMPLATE: &str = r##"#!/usr/bin/env python3
+"""
+__APP_NAME__ - Built with ucharm
+"""
+from ucharm import box, success, error, warning, info
+from ucharm import select, confirm, prompt
+
+
+def main():
+    box(
+        "__APP_NAME__\n"
+        "Built with ucharm",
+        title="Welcome",
+        border_color="cyan"
+    )
+    print()
+
+    choice = select("What would you like to do?", [
+        "Say hello",
+        "Show status messages",
+        "Exit"
+    ])
+
+    if choice == "Say hello":
+        name = prompt("What's your name?", default="World")
+        print()
+        success(f"Hello, {name}!")
+    elif choice == "Show status messages":
+        print()
+        success("This is a success message")
+        warning("This is a warning message")
+        error("This is an error message")
+        info("This is an info message")
+    else:
+        info("Goodbye!")
+
+
+if __name__ == "__main__":
+    main()
+"##;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AiInstructions {
+    Agents,
+    Claude,
+    Copilot,
+    All,
+}
+
+impl AiInstructions {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "agents" => Some(Self::Agents),
+            "claude" => Some(Self::Claude),
+            "copilot" => Some(Self::Copilot),
+            "all" => Some(Self::All),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ProjectOptions {
+    pub add_stubs: bool,
+    pub ai: Option<AiInstructions>,
+    pub create_app: bool,
+    pub app_name: Option<String>,
+}
+
+pub fn sanitize_name(name: &str) -> Result<String, &'static str> {
+    if name.is_empty() {
+        return Err("project name cannot be empty");
+    }
+    if name.len() > 240 {
+        return Err("project name is too long");
+    }
+    if name.chars().any(|character| {
+        character == '/' || character == '\\' || character == '\0' || character.is_control()
+    }) {
+        return Err("project name cannot contain path separators or control characters");
+    }
+
+    let sanitized: String = name
+        .chars()
+        .map(|character| match character {
+            ' ' | '-' => '_',
+            'A'..='Z' => character.to_ascii_lowercase(),
+            _ => character,
+        })
+        .collect();
+    if sanitized == "." || sanitized == ".." || sanitized.is_empty() {
+        return Err("project name is not valid");
+    }
+    Ok(sanitized)
+}
+
+pub fn initialize(
+    directory: &Path,
+    options: &ProjectOptions,
+    output: &mut dyn Write,
+) -> io::Result<usize> {
+    let mut files_created = 0;
+
+    if options.create_app
+        && let Some(name) = &options.app_name
+    {
+        files_created += create_app(directory, name, output)? as usize;
+    }
+
+    if options.add_stubs {
+        let stub_directory = directory.join(".ucharm/stubs");
+        fs::create_dir_all(&stub_directory)?;
+        for (name, content) in STUBS {
+            fs::write(stub_directory.join(name), content)?;
+        }
+        writeln!(
+            output,
+            "{GREEN}+{RESET} Created .ucharm/stubs/ ({} stub files)",
+            STUBS.len()
+        )?;
+        files_created += 1;
+        files_created += write_if_absent(
+            &directory.join("pyrightconfig.json"),
+            PYRIGHT_CONFIG,
+            "pyrightconfig.json",
+            output,
+        )? as usize;
+    }
+
+    if let Some(ai) = options.ai {
+        if matches!(ai, AiInstructions::Agents | AiInstructions::All) {
+            files_created += write_if_absent(
+                &directory.join("AGENTS.md"),
+                include_str!("../../../cli/src/templates/AGENTS.md"),
+                "AGENTS.md",
+                output,
+            )? as usize;
+        }
+        if matches!(ai, AiInstructions::Claude | AiInstructions::All) {
+            files_created += write_if_absent(
+                &directory.join("CLAUDE.md"),
+                include_str!("../../../cli/src/templates/CLAUDE.md"),
+                "CLAUDE.md",
+                output,
+            )? as usize;
+        }
+        if matches!(ai, AiInstructions::Copilot | AiInstructions::All) {
+            let copilot_path = directory.join(".github/copilot-instructions.md");
+            fs::create_dir_all(copilot_path.parent().expect("Copilot path has a parent"))?;
+            files_created += write_if_absent(
+                &copilot_path,
+                include_str!("../../../cli/src/templates/copilot-instructions.md"),
+                ".github/copilot-instructions.md",
+                output,
+            )? as usize;
+        }
+    }
+
+    Ok(files_created)
+}
+
+fn create_app(directory: &Path, name: &str, output: &mut dyn Write) -> io::Result<bool> {
+    let filename = format!("{}.py", sanitize_name(name).map_err(io::Error::other)?);
+    let path = directory.join(&filename);
+    let content = APP_TEMPLATE.replace("__APP_NAME__", name);
+    let created = write_if_absent(&path, &content, &filename, output)?;
+    if created {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(created)
+}
+
+fn write_if_absent(
+    path: &Path,
+    content: &str,
+    display_path: &str,
+    output: &mut dyn Write,
+) -> io::Result<bool> {
+    let mut file = match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            writeln!(
+                output,
+                "{DIM}-{RESET} {display_path} already exists (skipped)"
+            )?;
+            return Ok(false);
+        }
+        Err(error) => return Err(error),
+    };
+    file.write_all(content.as_bytes())?;
+    writeln!(output, "{GREEN}+{RESET} Created {display_path}")?;
+    Ok(true)
+}

--- a/crates/ucharm-cli/tests/cli.rs
+++ b/crates/ucharm-cli/tests/cli.rs
@@ -1,0 +1,139 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[test]
+fn reports_version_help_unknown_and_unmigrated_commands() {
+    let temporary = TestDirectory::new("dispatch");
+
+    let version = run(&temporary, &["--version"]);
+    assert!(version.status.success());
+    assert!(text(&version.stdout).contains(ucharm_cli::version()));
+
+    let help = run(&temporary, &["--help"]);
+    assert!(help.status.success());
+    assert!(text(&help.stdout).contains("COMMANDS"));
+
+    let unknown = run(&temporary, &["unknown"]);
+    assert!(!unknown.status.success());
+    assert!(text(&unknown.stderr).contains("Unknown command"));
+
+    let build = run(&temporary, &["build"]);
+    assert!(!build.status.success());
+    assert!(text(&build.stderr).contains("has not migrated to Rust yet"));
+}
+
+#[test]
+fn new_creates_an_executable_project_and_refuses_duplicates() {
+    let temporary = TestDirectory::new("new project");
+    let created = run(&temporary, &["new", "Test App"]);
+    assert!(created.status.success(), "{}", text(&created.stderr));
+
+    let app = temporary.path.join("test_app/test_app.py");
+    let content = fs::read_to_string(&app).expect("read generated app");
+    assert!(content.contains("Test App - Built with ucharm"));
+    assert_ne!(
+        fs::metadata(&app)
+            .expect("app metadata")
+            .permissions()
+            .mode()
+            & 0o111,
+        0
+    );
+
+    let duplicate = run(&temporary, &["new", "Test App"]);
+    assert!(!duplicate.status.success());
+    assert!(text(&duplicate.stderr).contains("already exists"));
+}
+
+#[test]
+fn minimal_project_stays_in_the_current_directory() {
+    let temporary = TestDirectory::new("minimal");
+    let created = run(&temporary, &["new", "Minimal App", "--minimal"]);
+    assert!(created.status.success(), "{}", text(&created.stderr));
+    assert!(temporary.path.join("minimal_app.py").is_file());
+    assert!(!temporary.path.join("minimal_app").exists());
+}
+
+#[test]
+fn init_installs_stubs_and_ai_files_without_overwriting_instructions() {
+    let temporary = TestDirectory::new("init");
+    let initialized = run(&temporary, &["init", "--all"]);
+    assert!(
+        initialized.status.success(),
+        "{}",
+        text(&initialized.stderr)
+    );
+
+    let stubs = temporary.path.join(".ucharm/stubs");
+    assert_eq!(fs::read_dir(stubs).expect("read stubs").count(), 24);
+    assert!(temporary.path.join("pyrightconfig.json").is_file());
+    assert!(temporary.path.join("AGENTS.md").is_file());
+    assert!(temporary.path.join("CLAUDE.md").is_file());
+    assert!(
+        temporary
+            .path
+            .join(".github/copilot-instructions.md")
+            .is_file()
+    );
+
+    fs::write(temporary.path.join("AGENTS.md"), "keep me\n").expect("replace fixture");
+    let repeated = run(&temporary, &["init", "--ai", "agents"]);
+    assert!(repeated.status.success());
+    assert_eq!(
+        fs::read_to_string(temporary.path.join("AGENTS.md")).expect("read fixture"),
+        "keep me\n"
+    );
+    assert!(text(&repeated.stdout).contains("already exists (skipped)"));
+}
+
+#[test]
+fn rejects_invalid_ai_types_and_path_traversal_names() {
+    let temporary = TestDirectory::new("invalid");
+
+    let ai = run(&temporary, &["init", "--ai", "robot"]);
+    assert!(!ai.status.success());
+    assert!(text(&ai.stderr).contains("invalid --ai type"));
+
+    let traversal = run(&temporary, &["new", "../escape"]);
+    assert!(!traversal.status.success());
+    assert!(text(&traversal.stderr).contains("path separators"));
+}
+
+fn run(temporary: &TestDirectory, arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ucharm-rs"))
+        .args(arguments)
+        .current_dir(&temporary.path)
+        .output()
+        .expect("run Rust CLI")
+}
+
+fn text(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+struct TestDirectory {
+    path: PathBuf,
+}
+
+impl TestDirectory {
+    fn new(name: &str) -> Self {
+        let counter = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "ucharm-cli-test-{}-{counter}-{name}",
+            std::process::id()
+        ));
+        fs::create_dir(&path).expect("create test directory");
+        Self { path }
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}

--- a/justfile
+++ b/justfile
@@ -19,6 +19,10 @@ rust-build:
 rust-run code:
     cargo run -p ucharm-runtime --bin pocketpy-ucharm-rs -- -c {{ quote(code) }}
 
+# Run the Rust CLI migration binary
+rust-cli *args:
+    cargo run -p ucharm-cli --bin ucharm-rs -- {{ args }}
+
 # Regenerate the checked-in PocketPy FFI declarations
 rust-bindings:
     ./scripts/generate-rust-bindings.sh


### PR DESCRIPTION
## Summary

- add a dependency-free `ucharm-cli` workspace crate and migration binary
- port the production dispatcher, branding, help/version output, `new`, and `init`
- preserve Zig output, generated project bytes, embedded stubs/templates, and executable modes
- reject path-traversal project names and unsafe/invalid option values
- add golden, filesystem, overwrite, and dispatch tests
- smoke-test and size-gate the CLI across all four release targets
- record Phase 2 completion and Phase 3 progress in the migration plan

The production Zig CLI remains unchanged. Unported `run`, `build`, and `test` commands fail explicitly in `ucharm-rs` until their migration slices land.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo audit`
- release workspace build on macOS ARM64
- release CLI build for `x86_64-apple-darwin`
- direct Zig/Rust byte comparisons for main/new/init help, version, unknown-command output, `new --all`, and `init --all`
- recursive generated-project comparison and executable-mode comparison

Local stripped CLI sizes: 335,904 bytes (macOS ARM64) and 329,312 bytes (macOS x86_64).