### PR TITLE
Port the test command to Rust

### DIFF
--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -155,10 +155,11 @@ status, stdout, and stderr.
   byte-level trailer and cache-hash vectors. The measured Rust loader adds
   9.2% to a universal application while slightly improving warm startup; the
   accepted size variance is recorded in `benchmarks/loader_migration_baseline.md`.
-- Phase 3 is in progress: `ucharm-cli` has the production command dispatcher
-  plus `new`, `init`, `run`, and `build`. Valid command output, generated files,
-  file modes, embedded stubs, assistant instructions, script transformation,
-  argument forwarding, and runtime exit codes have parity with the Zig CLI.
+- Phase 3 is functionally complete: `ucharm-cli` has the production command
+  dispatcher plus `new`, `init`, `run`, `build`, and `test`. Valid command
+  output, generated files, file modes, embedded stubs, assistant instructions,
+  script transformation, argument forwarding, and runtime exit codes have
+  parity with the Zig CLI.
   Unlike the legacy `run`, the Rust command embeds the matching released
   runtime on all four targets and uses a private, atomic, content-addressed
   cache. Its size and warm execution baseline is recorded in
@@ -166,8 +167,9 @@ status, stdout, and stderr.
   byte-identical host artifacts, and universal cross-builds use the released
   loader/runtime pair with the shared trailer encoder. Missing cross-target
   runtimes are resolved from the versioned cache or downloaded with SHA-256
-  verification. Only `test` remains explicitly delegated to the production Zig
-  CLI.
+  verification. The Rust `test` command runs single files and the CPython
+  compatibility runner with the source-built runtime during development and
+  the embedded released runtime as a self-contained fallback.
 - The initial stripped macOS ARM64 Rust spine is about 600 KB before μcharm's
   native modules and external C dependencies are added. This is an early
   feasibility signal, not a final size comparison.

--- a/crates/ucharm-cli/src/lib.rs
+++ b/crates/ucharm-cli/src/lib.rs
@@ -1,6 +1,7 @@
 mod build_command;
 mod project;
 mod run_command;
+mod test_command;
 
 use std::fs;
 use std::io::{self, Write};
@@ -51,17 +52,7 @@ pub fn run(
         "init" => run_init(&arguments[1..], current_directory, stdout, stderr),
         "run" => run_command::execute(&arguments[1..], current_directory, stdout, stderr),
         "build" => build_command::execute(&arguments[1..], current_directory, stdout, stderr),
-        "test" => {
-            writeln!(
-                stderr,
-                "{RED}Error:{RESET} Command '{BOLD}{command}{RESET}' has not migrated to Rust yet"
-            )?;
-            writeln!(
-                stderr,
-                "{DIM}Use the production Zig CLI for this command during the migration.{RESET}"
-            )?;
-            Ok(1)
-        }
+        "test" => test_command::execute(&arguments[1..], current_directory, stdout, stderr),
         unknown => {
             writeln!(
                 stderr,

--- a/crates/ucharm-cli/src/run_command.rs
+++ b/crates/ucharm-cli/src/run_command.rs
@@ -129,7 +129,7 @@ pub fn help() -> String {
     )
 }
 
-fn prepare_runtime() -> io::Result<PathBuf> {
+pub(crate) fn prepare_runtime() -> io::Result<PathBuf> {
     if EMBEDDED_RUNTIME.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::Unsupported,

--- a/crates/ucharm-cli/src/test_command.rs
+++ b/crates/ucharm-cli/src/test_command.rs
@@ -1,0 +1,266 @@
+use std::env;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus};
+
+use crate::run_command;
+
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const RED: &str = "\x1b[31m";
+const CYAN: &str = "\x1b[36m";
+
+#[derive(Debug, Default, Eq, PartialEq)]
+struct Options {
+    compat: bool,
+    report: bool,
+    verbose: bool,
+    module: Option<String>,
+    test_file: Option<String>,
+}
+
+pub fn execute(
+    arguments: &[String],
+    current_directory: &Path,
+    stdout: &mut dyn Write,
+    _stderr: &mut dyn Write,
+) -> io::Result<u8> {
+    let Some(options) = parse(arguments, stdout)? else {
+        return Ok(0);
+    };
+
+    if options.compat {
+        run_compat_tests(&options, current_directory, stdout)
+    } else if let Some(test_file) = options.test_file {
+        run_single_test(&test_file, current_directory, stdout)
+    } else {
+        write!(stdout, "{}", help())?;
+        Ok(0)
+    }
+}
+
+fn parse(arguments: &[String], stdout: &mut dyn Write) -> io::Result<Option<Options>> {
+    let mut options = Options::default();
+    let mut index = 0;
+
+    while index < arguments.len() {
+        match arguments[index].as_str() {
+            "--compat" => options.compat = true,
+            "--report" | "-r" => options.report = true,
+            "--verbose" | "-v" => options.verbose = true,
+            "--module" | "-m" => {
+                index += 1;
+                if let Some(module) = arguments.get(index) {
+                    options.module = Some(module.clone());
+                }
+            }
+            "-h" | "--help" => {
+                write!(stdout, "{}", help())?;
+                return Ok(None);
+            }
+            argument if !argument.starts_with('-') => {
+                options.test_file = Some(argument.to_owned());
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    Ok(Some(options))
+}
+
+fn run_compat_tests(
+    options: &Options,
+    current_directory: &Path,
+    stdout: &mut dyn Write,
+) -> io::Result<u8> {
+    let Some(runner_path) = find_compat_runner(current_directory) else {
+        writeln!(
+            stdout,
+            "{RED}Error:{RESET} Could not find tests/compat_runner.py"
+        )?;
+        writeln!(
+            stdout,
+            "{DIM}Make sure you're running from the ucharm repository root.{RESET}"
+        )?;
+        return Ok(1);
+    };
+    let runtime_path = runtime_path(current_directory)?;
+
+    let mut command = Command::new("python3");
+    command
+        .arg(runner_path)
+        .arg("--runtime")
+        .arg(runtime_path)
+        .current_dir(current_directory);
+    if options.verbose {
+        command.arg("--verbose");
+    }
+    if options.report {
+        command.arg("--report");
+    }
+    if let Some(module) = &options.module {
+        command.arg("--module").arg(module);
+    }
+
+    stdout.flush()?;
+    exit_code(command.status()?)
+}
+
+fn find_compat_runner(current_directory: &Path) -> Option<PathBuf> {
+    if let Some(path) = env::var_os("UCHARM_COMPAT_RUNNER").map(PathBuf::from)
+        && path.is_file()
+    {
+        return Some(path);
+    }
+
+    if let Ok(executable) = env::current_exe()
+        && let Some(binary_directory) = executable.parent()
+    {
+        for ancestor in binary_directory.ancestors().take(4) {
+            let candidate = ancestor.join("tests/compat_runner.py");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    let current_path = current_directory.join("tests/compat_runner.py");
+    if current_path.is_file() {
+        return Some(current_path);
+    }
+
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/compat_runner.py");
+    source_path.is_file().then_some(source_path)
+}
+
+fn runtime_path(current_directory: &Path) -> io::Result<PathBuf> {
+    if let Some(path) = env::var_os("UCHARM_TEST_RUNTIME").map(PathBuf::from)
+        && path.is_file()
+    {
+        return Ok(path);
+    }
+
+    if let Ok(executable) = env::current_exe()
+        && let Some(binary_directory) = executable.parent()
+    {
+        for ancestor in binary_directory.ancestors().take(6) {
+            let candidate = ancestor.join("pocketpy/zig-out/bin/pocketpy-ucharm");
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+        let sibling = binary_directory.join("pocketpy-ucharm");
+        if sibling.is_file() {
+            return Ok(sibling);
+        }
+    }
+
+    let current_path = current_directory.join("pocketpy/zig-out/bin/pocketpy-ucharm");
+    if current_path.is_file() {
+        return Ok(current_path);
+    }
+
+    let source_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../pocketpy/zig-out/bin/pocketpy-ucharm");
+    if source_path.is_file() {
+        return Ok(source_path);
+    }
+
+    run_command::prepare_runtime()
+}
+
+fn run_single_test(
+    test_file: &str,
+    current_directory: &Path,
+    stdout: &mut dyn Write,
+) -> io::Result<u8> {
+    let runtime_path = runtime_path(current_directory)?;
+    writeln!(stdout, "Running {test_file} with pocketpy-ucharm...\n")?;
+    stdout.flush()?;
+
+    let status = Command::new(runtime_path)
+        .arg(test_file)
+        .current_dir(current_directory)
+        .status()?;
+    exit_code(status)
+}
+
+fn exit_code(status: ExitStatus) -> io::Result<u8> {
+    match status.code() {
+        Some(code) => u8::try_from(code).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("child process returned invalid exit code {code}"),
+            )
+        }),
+        None => Ok(1),
+    }
+}
+
+pub fn help() -> String {
+    format!(
+        "\n  {CYAN}{BOLD}μcharm test{RESET} - CPython Compatibility Testing\n\n{BOLD}USAGE{RESET}\n    ucharm test [options] [file]\n\n{BOLD}OPTIONS{RESET}\n    {CYAN}--compat{RESET}        Run full CPython compatibility test suite\n    {CYAN}--report{RESET}, -r    Generate compat_report.md\n    {CYAN}--verbose{RESET}, -v   Show failure details\n    {CYAN}--module{RESET}, -m    Test only specified module\n    {CYAN}-h{RESET}, --help      Show this help\n\n{BOLD}EXAMPLES{RESET}\n    {DIM}${RESET} ucharm test --compat              {DIM}# Full compatibility suite{RESET}\n    {DIM}${RESET} ucharm test --compat --report     {DIM}# Generate markdown report{RESET}\n    {DIM}${RESET} ucharm test --compat -m functools {DIM}# Test single module{RESET}\n    {DIM}${RESET} ucharm test mytest.py             {DIM}# Run with pocketpy-ucharm{RESET}\n\n{BOLD}ABOUT{RESET}\n    Tests μcharm's compatibility with CPython standard library.\n    Runs each test file with both CPython and pocketpy-ucharm,\n    comparing results to calculate compatibility percentages.\n\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Options, help, parse};
+
+    #[test]
+    fn parses_legacy_options() {
+        let arguments = [
+            "--compat",
+            "-r",
+            "--verbose",
+            "--module",
+            "functools",
+            "first.py",
+            "last.py",
+            "--unknown",
+        ]
+        .map(str::to_owned);
+        let mut stdout = Vec::new();
+
+        assert_eq!(
+            parse(&arguments, &mut stdout).expect("parse options"),
+            Some(Options {
+                compat: true,
+                report: true,
+                verbose: true,
+                module: Some("functools".to_owned()),
+                test_file: Some("last.py".to_owned()),
+            })
+        );
+        assert!(stdout.is_empty());
+    }
+
+    #[test]
+    fn help_matches_the_zig_cli() {
+        assert_eq!(
+            help(),
+            concat!(
+                "\n  \x1b[36m\x1b[1mμcharm test\x1b[0m - CPython Compatibility Testing\n\n",
+                "\x1b[1mUSAGE\x1b[0m\n",
+                "    ucharm test [options] [file]\n\n",
+                "\x1b[1mOPTIONS\x1b[0m\n",
+                "    \x1b[36m--compat\x1b[0m        Run full CPython compatibility test suite\n",
+                "    \x1b[36m--report\x1b[0m, -r    Generate compat_report.md\n",
+                "    \x1b[36m--verbose\x1b[0m, -v   Show failure details\n",
+                "    \x1b[36m--module\x1b[0m, -m    Test only specified module\n",
+                "    \x1b[36m-h\x1b[0m, --help      Show this help\n\n",
+                "\x1b[1mEXAMPLES\x1b[0m\n",
+                "    \x1b[2m$\x1b[0m ucharm test --compat              \x1b[2m# Full compatibility suite\x1b[0m\n",
+                "    \x1b[2m$\x1b[0m ucharm test --compat --report     \x1b[2m# Generate markdown report\x1b[0m\n",
+                "    \x1b[2m$\x1b[0m ucharm test --compat -m functools \x1b[2m# Test single module\x1b[0m\n",
+                "    \x1b[2m$\x1b[0m ucharm test mytest.py             \x1b[2m# Run with pocketpy-ucharm\x1b[0m\n\n",
+                "\x1b[1mABOUT\x1b[0m\n",
+                "    Tests μcharm's compatibility with CPython standard library.\n",
+                "    Runs each test file with both CPython and pocketpy-ucharm,\n",
+                "    comparing results to calculate compatibility percentages.\n\n",
+            )
+        );
+    }
+}

--- a/crates/ucharm-cli/tests/cli.rs
+++ b/crates/ucharm-cli/tests/cli.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[test]
-fn reports_version_help_unknown_and_unmigrated_commands() {
+fn reports_version_help_and_unknown_commands() {
     let temporary = TestDirectory::new("dispatch");
 
     let version = run(&temporary, &["--version"]);
@@ -26,9 +26,9 @@ fn reports_version_help_unknown_and_unmigrated_commands() {
     assert!(build_help.status.success());
     assert!(text(&build_help.stdout).contains("Build standalone binaries"));
 
-    let test_command = run(&temporary, &["test"]);
-    assert!(!test_command.status.success());
-    assert!(text(&test_command.stderr).contains("has not migrated to Rust yet"));
+    let test_help = run(&temporary, &["test", "--help"]);
+    assert!(test_help.status.success());
+    assert!(text(&test_help.stdout).contains("CPython Compatibility Testing"));
 
     let run_help = run(&temporary, &["run", "--help"]);
     assert!(run_help.status.success());
@@ -47,6 +47,45 @@ fn reports_version_help_unknown_and_unmigrated_commands() {
         text(&missing_script.stderr),
         "\x1b[31mError:\x1b[0m Script not found: missing.py\n"
     );
+}
+
+#[test]
+fn test_runs_single_files_and_propagates_failures() {
+    let temporary = TestDirectory::new("test files");
+    fs::write(
+        temporary.path.join("passing test.py"),
+        "print('single test passed')\n",
+    )
+    .expect("write passing test");
+
+    let passed = run(&temporary, &["test", "passing test.py"]);
+    assert!(passed.status.success(), "{}", text(&passed.stderr));
+    assert_eq!(
+        text(&passed.stdout),
+        "Running passing test.py with pocketpy-ucharm...\n\nsingle test passed\n"
+    );
+    assert_eq!(text(&passed.stderr), "");
+
+    fs::write(
+        temporary.path.join("failing.py"),
+        "raise RuntimeError('expected test failure')\n",
+    )
+    .expect("write failing test");
+    let failed = run(&temporary, &["test", "failing.py"]);
+    assert_eq!(failed.status.code(), Some(1));
+    assert!(text(&failed.stdout).contains("RuntimeError: expected test failure"));
+    assert!(text(&failed.stderr).contains("PocketPyExecFailed"));
+}
+
+#[test]
+fn test_runs_the_compatibility_runner_with_the_resolved_runtime() {
+    let temporary = TestDirectory::new("compatibility");
+    let tested = run(&temporary, &["test", "--compat", "--module", "errno"]);
+
+    assert!(tested.status.success(), "{}", text(&tested.stderr));
+    assert!(text(&tested.stdout).contains("errno"));
+    assert!(text(&tested.stdout).contains("38/38"));
+    assert_eq!(text(&tested.stderr), "");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- port the legacy `ucharm test` parser, help, single-file execution, and compatibility-runner mode to Rust
- prefer the source-built PocketPy runtime in a development checkout and fall back to the embedded release runtime
- preserve child exit codes and add unit/integration coverage for help, options, successful files, failures, and a real compatibility module
- mark Phase 3 of the Rust migration functionally complete

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo audit`
- release workspace build plus Intel macOS release build
- checks for both Linux musl targets
- full compatibility suite: 1,668 / 1,668 passing (100%)
- byte-for-byte Zig/Rust parity for test help and single-file output
- release CLI sizes remain below 3.5 MB on ARM64 and Intel macOS