### PR TITLE
Port the terminal runtime to Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
         run: >-
           target/${{ matrix.target }}/release/pocketpy-ucharm-rs
-          -c 'import _ucharm_rust, ansi; assert _ucharm_rust.answer() == 42; assert ansi.fg("red") == "\x1b[31m"'
+          -c 'import _ucharm_rust, ansi, args, term; assert _ucharm_rust.answer() == 42; assert ansi.fg("red") == "\x1b[31m"; assert args.count() == 1; assert len(term.size()) == 2; assert term.raw_mode(False) is None'
       - name: Smoke-test Rust CLI
         shell: bash
         run: target/${{ matrix.target }}/release/ucharm-rs --version | grep -q "μcharm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,5 +147,6 @@ dependencies = [
 name = "ucharm-runtime"
 version = "0.5.0"
 dependencies = [
+ "libc",
  "ucharm-pocketpy-sys",
 ]

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -173,11 +173,14 @@ status, stdout, and stderr.
 - Phase 4 is in progress: the generated PocketPy bindings now expose the small
   container, type-object, and temporary-rooting surface required by native
   callbacks. Module registration is table-driven, and the `ansi` and complete
-  `args` modules are ported with Python-level behavior, error, and allocation
-  stress tests. The rooted Rust `args` implementation also fixes the legacy
-  alias-key corruption and SIGSEGV exposed by combined alias/default parsing.
-  The `_ucharm_rust` probe remains temporarily as an FFI smoke test while
-  production modules cross the boundary; TUI and input core logic are next.
+  `args` and `term` modules are ported with Python-level behavior, error,
+  allocation-stress, byte-stream, and pseudo-terminal tests. The rooted Rust
+  `args` implementation fixes the legacy alias-key corruption and SIGSEGV
+  exposed by combined alias/default parsing. Rust now also owns raw terminal
+  state and restores it during VM teardown. The allocation-free input
+  navigation core is ported; the complete interactive `input` module is the
+  next PTY and state-machine slice. The `_ucharm_rust` probe remains
+  temporarily as an FFI smoke test while production modules cross the boundary.
 - The initial stripped macOS ARM64 Rust spine is about 600 KB before μcharm's
   native modules and external C dependencies are added. This is an early
   feasibility signal, not a final size comparison.

--- a/crates/pocketpy-sys/src/bindings.rs
+++ b/crates/pocketpy-sys/src/bindings.rs
@@ -149,7 +149,14 @@ unsafe extern "C" {
     pub fn py_exception(type_: py_Type, fmt: *const ::core::ffi::c_char, ...) -> bool;
 }
 unsafe extern "C" {
+    #[doc = " Create a `tuple` with `n` UNINITIALIZED elements.\n You should initialize all elements before using it."]
+    pub fn py_newtuple(arg1: py_OutRef, n: ::core::ffi::c_int) -> py_ObjectRef;
+}
+unsafe extern "C" {
     pub fn py_tuple_getitem(self_: py_Ref, i: ::core::ffi::c_int) -> py_ObjectRef;
+}
+unsafe extern "C" {
+    pub fn py_tuple_setitem(self_: py_Ref, i: ::core::ffi::c_int, val: py_Ref);
 }
 unsafe extern "C" {
     pub fn py_tuple_len(self_: py_Ref) -> ::core::ffi::c_int;

--- a/crates/ucharm-runtime/Cargo.toml
+++ b/crates/ucharm-runtime/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+libc = "0.2"
 ucharm-pocketpy-sys = { path = "../pocketpy-sys" }
 
 [lints]

--- a/crates/ucharm-runtime/src/input_core.rs
+++ b/crates/ucharm-runtime/src/input_core.rs
@@ -1,0 +1,69 @@
+//! Allocation-free primitives shared by μcharm's interactive input module.
+
+#[must_use]
+pub fn string_length(value: &str) -> usize {
+    value.len()
+}
+
+#[must_use]
+pub fn strings_equal(left: &str, right: &str) -> bool {
+    left == right
+}
+
+#[must_use]
+pub fn starts_with(value: &str, prefix: &str) -> bool {
+    value.starts_with(prefix)
+}
+
+/// Clamps without panicking when the legacy caller supplies an inverted range.
+#[must_use]
+pub fn clamp(value: i32, minimum: i32, maximum: i32) -> i32 {
+    if value < minimum {
+        minimum
+    } else if value > maximum {
+        maximum
+    } else {
+        value
+    }
+}
+
+#[must_use]
+pub fn wrap_index(value: i32, count: i32) -> i32 {
+    if count <= 0 {
+        0
+    } else {
+        value.rem_euclid(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{clamp, starts_with, string_length, strings_equal, wrap_index};
+
+    #[test]
+    fn string_vectors_match_zig() {
+        assert_eq!(string_length("hello"), 5);
+        assert_eq!(string_length(""), 0);
+        assert!(strings_equal("hello", "hello"));
+        assert!(!strings_equal("hello", "world"));
+        assert!(!strings_equal("hello", "hell"));
+        assert!(starts_with("hello world", "hello"));
+        assert!(!starts_with("hello", "world"));
+        assert!(starts_with("hello", ""));
+    }
+
+    #[test]
+    fn navigation_vectors_match_and_extend_zig() {
+        assert_eq!(clamp(5, 0, 10), 5);
+        assert_eq!(clamp(-5, 0, 10), 0);
+        assert_eq!(clamp(15, 0, 10), 10);
+        assert_eq!(clamp(5, 10, 0), 10);
+
+        assert_eq!(wrap_index(0, 5), 0);
+        assert_eq!(wrap_index(1, 5), 1);
+        assert_eq!(wrap_index(5, 5), 0);
+        assert_eq!(wrap_index(-1, 5), 4);
+        assert_eq!(wrap_index(1, 0), 0);
+        assert_eq!(wrap_index(1, -1), 0);
+    }
+}

--- a/crates/ucharm-runtime/src/lib.rs
+++ b/crates/ucharm-runtime/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod args_core;
+pub mod input_core;
 mod modules;
 mod native;
 
@@ -162,6 +163,7 @@ unsafe extern "C" fn probe_answer(_argc: i32, _argv: ffi::py_StackRef) -> bool {
 
 impl Drop for Vm {
     fn drop(&mut self) {
+        modules::shutdown_all();
         // SAFETY: `Vm` is the unique process-wide owner and finalization occurs
         // exactly once. PocketPy documents finalization as irreversible.
         unsafe { ffi::py_finalize() };

--- a/crates/ucharm-runtime/src/modules/mod.rs
+++ b/crates/ucharm-runtime/src/modules/mod.rs
@@ -1,11 +1,17 @@
 mod ansi;
 mod ansi_core;
 mod args;
+mod term;
+mod term_core;
 
 use crate::native::{NativeModule, register_modules};
 
-const MODULES: &[NativeModule] = &[ansi::MODULE, args::MODULE];
+const MODULES: &[NativeModule] = &[ansi::MODULE, args::MODULE, term::MODULE];
 
 pub(crate) fn register_all() {
     register_modules(MODULES);
+}
+
+pub(crate) fn shutdown_all() {
+    term::shutdown();
 }

--- a/crates/ucharm-runtime/src/modules/term.rs
+++ b/crates/ucharm-runtime/src/modules/term.rs
@@ -1,0 +1,332 @@
+use std::io::{self, IsTerminal, Read, Write};
+use std::mem::MaybeUninit;
+use std::sync::{Mutex, MutexGuard};
+
+use ucharm_pocketpy_sys as ffi;
+
+use super::term_core::{self, DecodedKey};
+use crate::native::{
+    Arguments, NativeFunction, NativeModule, RootFrame, return_string, return_string_bytes,
+    return_value, runtime_error, type_error,
+};
+
+const FUNCTIONS: &[NativeFunction] = &[
+    NativeFunction {
+        name: c"size",
+        callback: size,
+    },
+    NativeFunction {
+        name: c"raw_mode",
+        callback: raw_mode,
+    },
+    NativeFunction {
+        name: c"read_key",
+        callback: read_key,
+    },
+    NativeFunction {
+        name: c"cursor_pos",
+        callback: cursor_pos,
+    },
+    NativeFunction {
+        name: c"cursor_up",
+        callback: cursor_up,
+    },
+    NativeFunction {
+        name: c"cursor_down",
+        callback: cursor_down,
+    },
+    NativeFunction {
+        name: c"cursor_left",
+        callback: cursor_left,
+    },
+    NativeFunction {
+        name: c"cursor_right",
+        callback: cursor_right,
+    },
+    NativeFunction {
+        name: c"clear",
+        callback: clear,
+    },
+    NativeFunction {
+        name: c"clear_line",
+        callback: clear_line,
+    },
+    NativeFunction {
+        name: c"hide_cursor",
+        callback: hide_cursor,
+    },
+    NativeFunction {
+        name: c"show_cursor",
+        callback: show_cursor,
+    },
+    NativeFunction {
+        name: c"is_tty",
+        callback: is_tty,
+    },
+    NativeFunction {
+        name: c"write",
+        callback: write,
+    },
+];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"term",
+    functions: FUNCTIONS,
+};
+
+#[derive(Default)]
+struct RawModeState {
+    original: Option<libc::termios>,
+}
+
+static RAW_MODE: Mutex<RawModeState> = Mutex::new(RawModeState { original: None });
+
+enum RawModeError {
+    Read,
+    Enable,
+}
+
+fn raw_mode_state() -> MutexGuard<'static, RawModeState> {
+    RAW_MODE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn enable_raw_mode() -> Result<(), RawModeError> {
+    let mut state = raw_mode_state();
+    if state.original.is_some() {
+        return Ok(());
+    }
+
+    let mut original = MaybeUninit::<libc::termios>::uninit();
+    // SAFETY: `original` points to writable storage and stdin is a valid file
+    // descriptor. A zero return initializes the entire `termios` value.
+    if unsafe { libc::tcgetattr(libc::STDIN_FILENO, original.as_mut_ptr()) } != 0 {
+        return Err(RawModeError::Read);
+    }
+    // SAFETY: the successful `tcgetattr` call initialized `original`.
+    let original = unsafe { original.assume_init() };
+    let mut raw = original;
+    raw.c_lflag &= !(libc::ECHO | libc::ICANON | libc::ISIG | libc::IEXTEN);
+    raw.c_iflag &= !(libc::IXON | libc::ICRNL | libc::BRKINT | libc::INPCK | libc::ISTRIP);
+    raw.c_oflag &= !libc::OPOST;
+    raw.c_cflag |= libc::CS8;
+    raw.c_cc[libc::VMIN] = 0;
+    raw.c_cc[libc::VTIME] = 1;
+
+    // SAFETY: both the file descriptor and initialized settings are valid for
+    // the duration of this call.
+    if unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSAFLUSH, &raw) } != 0 {
+        return Err(RawModeError::Enable);
+    }
+    state.original = Some(original);
+    Ok(())
+}
+
+fn restore_raw_mode() {
+    let mut state = raw_mode_state();
+    let Some(original) = state.original else {
+        return;
+    };
+    // SAFETY: stdin and the saved settings were valid when raw mode was
+    // enabled. Retain the saved value if restoration fails so shutdown gets
+    // another opportunity to restore it.
+    if unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSAFLUSH, &original) } == 0 {
+        state.original = None;
+    }
+}
+
+pub(super) fn shutdown() {
+    restore_raw_mode();
+}
+
+fn write_output(bytes: &[u8]) {
+    let mut output = io::stdout().lock();
+    let _ = output.write_all(bytes);
+    let _ = output.flush();
+}
+
+fn return_none() -> bool {
+    let mut roots = RootFrame::new();
+    let none = roots.none();
+    return_value(none)
+}
+
+fn return_bool(value: bool) -> bool {
+    let mut roots = RootFrame::new();
+    let value = roots.boolean(value);
+    return_value(value)
+}
+
+unsafe extern "C" fn size(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(0, 0) {
+        return false;
+    }
+
+    let mut window = MaybeUninit::<libc::winsize>::uninit();
+    // SAFETY: `window` points to writable storage and stdout is a valid file
+    // descriptor. A successful ioctl initializes the structure.
+    let status = unsafe { libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, window.as_mut_ptr()) };
+    let (columns, rows) = if status == -1 {
+        (80_i64, 24_i64)
+    } else {
+        // SAFETY: the successful ioctl initialized `window`.
+        let window = unsafe { window.assume_init() };
+        if window.ws_col == 0 {
+            (80, 24)
+        } else {
+            (i64::from(window.ws_col), i64::from(window.ws_row))
+        }
+    };
+
+    let mut roots = RootFrame::new();
+    let Some(result) = roots.tuple(2) else {
+        return runtime_error(c"failed to create terminal size");
+    };
+    let columns = roots.integer(columns);
+    let rows = roots.integer(rows);
+    if !result.tuple_set(0, columns) || !result.tuple_set(1, rows) {
+        return runtime_error(c"failed to create terminal size");
+    }
+    return_value(result)
+}
+
+unsafe extern "C" fn raw_mode(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return false;
+    }
+    let Some(enable) = arguments.get(0).and_then(|value| value.boolean()) else {
+        return type_error(c"expected bool");
+    };
+    if enable {
+        match enable_raw_mode() {
+            Ok(()) => {}
+            Err(RawModeError::Read) => {
+                return runtime_error(c"failed to read terminal settings");
+            }
+            Err(RawModeError::Enable) => return runtime_error(c"failed to enable raw mode"),
+        }
+    } else {
+        restore_raw_mode();
+    }
+    return_none()
+}
+
+unsafe extern "C" fn read_key(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(0, 0) {
+        return false;
+    }
+    let mut buffer = [0_u8; 8];
+    let count = io::stdin().read(&mut buffer).unwrap_or(0);
+    match term_core::decode_key(&buffer[..count]) {
+        DecodedKey::None => return_none(),
+        DecodedKey::Named(name) => return_string(name),
+        DecodedKey::Text(bytes) => return_string_bytes(bytes),
+    }
+}
+
+unsafe extern "C" fn cursor_pos(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(2, 2) {
+        return false;
+    }
+    let Some(x) = arguments.get(0).and_then(|value| value.integer()) else {
+        return type_error(c"x must be int");
+    };
+    let Some(y) = arguments.get(1).and_then(|value| value.integer()) else {
+        return type_error(c"y must be int");
+    };
+    let Some(sequence) = term_core::cursor_position(x, y) else {
+        return runtime_error(c"failed to format cursor position");
+    };
+    write_output(sequence.as_bytes());
+    return_none()
+}
+
+fn move_cursor(argc: libc::c_int, argv: ffi::py_StackRef, direction: char) -> bool {
+    // SAFETY: called only from a PocketPy callback with its active argument stack.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(0, 1) {
+        return false;
+    }
+    let count = arguments
+        .get(0)
+        .and_then(|value| value.integer())
+        .unwrap_or(1);
+    let Some(sequence) = term_core::cursor_move(count, direction) else {
+        return runtime_error(c"failed to format cursor move");
+    };
+    write_output(sequence.as_bytes());
+    return_none()
+}
+
+unsafe extern "C" fn cursor_up(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    move_cursor(argc, argv, 'A')
+}
+
+unsafe extern "C" fn cursor_down(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    move_cursor(argc, argv, 'B')
+}
+
+unsafe extern "C" fn cursor_left(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    move_cursor(argc, argv, 'D')
+}
+
+unsafe extern "C" fn cursor_right(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    move_cursor(argc, argv, 'C')
+}
+
+fn fixed_output(argc: libc::c_int, argv: ffi::py_StackRef, bytes: &'static [u8]) -> bool {
+    // SAFETY: called only from a PocketPy callback with its active argument stack.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(0, 0) {
+        return false;
+    }
+    write_output(bytes);
+    return_none()
+}
+
+unsafe extern "C" fn clear(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    fixed_output(argc, argv, b"\x1b[2J\x1b[H")
+}
+
+unsafe extern "C" fn clear_line(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    fixed_output(argc, argv, b"\x1b[2K\r")
+}
+
+unsafe extern "C" fn hide_cursor(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    fixed_output(argc, argv, b"\x1b[?25l")
+}
+
+unsafe extern "C" fn show_cursor(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    fixed_output(argc, argv, b"\x1b[?25h")
+}
+
+unsafe extern "C" fn is_tty(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(0, 0) {
+        return false;
+    }
+    return_bool(io::stdout().is_terminal())
+}
+
+unsafe extern "C" fn write(argc: libc::c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return false;
+    }
+    let Some(text) = arguments.get(0).and_then(|value| value.string()) else {
+        return type_error(c"text must be a string");
+    };
+    write_output(text.as_bytes());
+    return_none()
+}

--- a/crates/ucharm-runtime/src/modules/term_core.rs
+++ b/crates/ucharm-runtime/src/modules/term_core.rs
@@ -1,0 +1,114 @@
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum DecodedKey<'a> {
+    None,
+    Named(&'static str),
+    Text(&'a [u8]),
+}
+
+pub(super) fn decode_key(bytes: &[u8]) -> DecodedKey<'_> {
+    if bytes.is_empty() {
+        return DecodedKey::None;
+    }
+
+    if bytes.len() >= 3 && bytes[0] == 0x1b && bytes[1] == b'[' {
+        let named = match bytes[2] {
+            b'A' => Some("up"),
+            b'B' => Some("down"),
+            b'C' => Some("right"),
+            b'D' => Some("left"),
+            b'H' => Some("home"),
+            b'F' => Some("end"),
+            _ => None,
+        };
+        if let Some(named) = named {
+            return DecodedKey::Named(named);
+        }
+
+        if bytes.get(3) == Some(&b'~') {
+            let named = match bytes[2] {
+                b'3' => Some("delete"),
+                b'5' => Some("pageup"),
+                b'6' => Some("pagedown"),
+                _ => None,
+            };
+            if let Some(named) = named {
+                return DecodedKey::Named(named);
+            }
+        }
+    }
+
+    if bytes.len() == 1 {
+        let named = match bytes[0] {
+            b'\r' | b'\n' => Some("enter"),
+            0x1b => Some("escape"),
+            0x7f | 0x08 => Some("backspace"),
+            b'\t' => Some("tab"),
+            3 => Some("ctrl-c"),
+            _ => None,
+        };
+        if let Some(named) = named {
+            return DecodedKey::Named(named);
+        }
+    }
+
+    DecodedKey::Text(bytes)
+}
+
+pub(super) fn cursor_position(x: i64, y: i64) -> Option<String> {
+    bounded(
+        format!("\x1b[{};{}H", y.wrapping_add(1), x.wrapping_add(1)),
+        32,
+    )
+}
+
+pub(super) fn cursor_move(count: i64, direction: char) -> Option<String> {
+    debug_assert!(matches!(direction, 'A' | 'B' | 'C' | 'D'));
+    bounded(format!("\x1b[{count}{direction}"), 16)
+}
+
+fn bounded(value: String, capacity: usize) -> Option<String> {
+    (value.len() <= capacity).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DecodedKey, cursor_move, cursor_position, decode_key};
+
+    #[test]
+    fn key_vectors_match_zig() {
+        for (bytes, expected) in [
+            (&b"\x1b[A"[..], "up"),
+            (&b"\x1b[B"[..], "down"),
+            (&b"\x1b[C"[..], "right"),
+            (&b"\x1b[D"[..], "left"),
+            (&b"\x1b[H"[..], "home"),
+            (&b"\x1b[F"[..], "end"),
+            (&b"\x1b[3~"[..], "delete"),
+            (&b"\x1b[5~"[..], "pageup"),
+            (&b"\x1b[6~"[..], "pagedown"),
+            (&b"\r"[..], "enter"),
+            (&b"\n"[..], "enter"),
+            (&b"\x1b"[..], "escape"),
+            (&b"\x7f"[..], "backspace"),
+            (&b"\x08"[..], "backspace"),
+            (&b"\t"[..], "tab"),
+            (&b"\x03"[..], "ctrl-c"),
+        ] {
+            assert_eq!(decode_key(bytes), DecodedKey::Named(expected));
+        }
+        assert_eq!(decode_key(b""), DecodedKey::None);
+        assert_eq!(decode_key(b"x"), DecodedKey::Text(b"x"));
+        assert_eq!(decode_key("é".as_bytes()), DecodedKey::Text("é".as_bytes()));
+        assert_eq!(decode_key(b"\x1b[Z"), DecodedKey::Text(b"\x1b[Z"));
+    }
+
+    #[test]
+    fn terminal_sequences_match_zig() {
+        assert_eq!(cursor_position(2, 3).as_deref(), Some("\x1b[4;3H"));
+        assert_eq!(cursor_position(-1, -1).as_deref(), Some("\x1b[0;0H"));
+        assert_eq!(cursor_move(1, 'A').as_deref(), Some("\x1b[1A"));
+        assert_eq!(cursor_move(-2, 'D').as_deref(), Some("\x1b[-2D"));
+        assert!(cursor_position(i64::MAX, i64::MAX).is_none());
+        assert!(cursor_move(i64::MIN, 'A').is_none());
+    }
+}

--- a/crates/ucharm-runtime/src/native.rs
+++ b/crates/ucharm-runtime/src/native.rs
@@ -91,6 +91,14 @@ impl Value {
         Some(unsafe { ffi::py_toint(self.raw) })
     }
 
+    pub fn boolean(self) -> Option<bool> {
+        if !self.is_type(ffi::py_PredefinedType_tp_bool) {
+            return None;
+        }
+        // SAFETY: the exact type check above establishes a boolean value.
+        Some(unsafe { ffi::py_tobool(self.raw) })
+    }
+
     pub fn string(self) -> Option<String> {
         if !self.is_type(ffi::py_PredefinedType_tp_str) {
             return None;
@@ -171,6 +179,22 @@ impl Value {
         Some(Self {
             raw: unsafe { ffi::py_tuple_getitem(self.raw, index) },
         })
+    }
+
+    pub fn tuple_set(self, index: usize, value: Self) -> bool {
+        let Some(length) = self.tuple_len() else {
+            return false;
+        };
+        if index >= length {
+            return false;
+        }
+        let Ok(index) = c_int::try_from(index) else {
+            return false;
+        };
+        // SAFETY: the exact type and bounds checks establish a valid tuple
+        // slot, and both values remain rooted during the assignment.
+        unsafe { ffi::py_tuple_setitem(self.raw, index, value.raw) };
+        true
     }
 
     pub fn dict_set(self, key: Self, value: Self) -> bool {
@@ -257,6 +281,15 @@ impl RootFrame {
         root
     }
 
+    pub fn tuple(&mut self, length: usize) -> Option<Value> {
+        let length = c_int::try_from(length).ok()?;
+        let root = self.push();
+        // SAFETY: `root` is writable VM stack storage and every tuple slot is
+        // initialized by the caller before the tuple becomes observable.
+        unsafe { ffi::py_newtuple(root.raw, length) };
+        Some(root)
+    }
+
     pub fn dict(&mut self) -> Value {
         let root = self.push();
         // SAFETY: `root` is writable VM stack storage.
@@ -303,6 +336,10 @@ pub(crate) fn return_value(value: Value) -> bool {
 }
 
 pub(crate) fn return_string(value: &str) -> bool {
+    return_string_bytes(value.as_bytes())
+}
+
+pub(crate) fn return_string_bytes(value: &[u8]) -> bool {
     let Ok(length) = c_int::try_from(value.len()) else {
         return type_error(c"return string is too large");
     };

--- a/crates/ucharm-runtime/tests/term.rs
+++ b/crates/ucharm-runtime/tests/term.rs
@@ -1,0 +1,228 @@
+use std::fs::File;
+use std::io::Write;
+use std::mem::MaybeUninit;
+use std::os::fd::FromRawFd;
+use std::process::{Command, Output, Stdio};
+use std::ptr;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn exposes_terminal_size_tty_and_output_controls() {
+    let output = run(
+        "import term\n\
+assert term.size() == (80, 24)\n\
+assert term.is_tty() is False\n\
+assert term.cursor_pos(2, 3) is None\n\
+assert term.cursor_up() is None\n\
+assert term.cursor_down(2) is None\n\
+assert term.cursor_left('defaults-to-one') is None\n\
+assert term.cursor_right(-4) is None\n\
+assert term.clear() is None\n\
+assert term.clear_line() is None\n\
+assert term.hide_cursor() is None\n\
+assert term.show_cursor() is None\n\
+assert term.write('done') is None",
+        b"",
+    );
+
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(
+        output.stdout,
+        b"\x1b[4;3H\x1b[1A\x1b[2B\x1b[1D\x1b[-4C\x1b[2J\x1b[H\x1b[2K\r\x1b[?25l\x1b[?25hdone"
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn decodes_terminal_keys() {
+    for (input, expected) in [
+        (&b"\x1b[A"[..], "'up'\n"),
+        (&b"\x1b[B"[..], "'down'\n"),
+        (&b"\x1b[C"[..], "'right'\n"),
+        (&b"\x1b[D"[..], "'left'\n"),
+        (&b"\x1b[H"[..], "'home'\n"),
+        (&b"\x1b[F"[..], "'end'\n"),
+        (&b"\x1b[3~"[..], "'delete'\n"),
+        (&b"\x1b[5~"[..], "'pageup'\n"),
+        (&b"\x1b[6~"[..], "'pagedown'\n"),
+        (&b"\r"[..], "'enter'\n"),
+        (&b"\x1b"[..], "'escape'\n"),
+        (&b"\x7f"[..], "'backspace'\n"),
+        (&b"\t"[..], "'tab'\n"),
+        (&b"\x03"[..], "'ctrl-c'\n"),
+        (&b"abc"[..], "'abc'\n"),
+        ("é".as_bytes(), "'é'\n"),
+        (&b"\x1b[Z"[..], "'\\x1b[Z'\n"),
+    ] {
+        let output = run("import term; print(repr(term.read_key()))", input);
+        assert!(output.status.success(), "{}", diagnostic(&output));
+        assert_eq!(text(&output.stdout), expected, "input: {input:?}");
+        assert!(output.stderr.is_empty());
+    }
+
+    let output = run("import term; print(repr(term.read_key()))", b"");
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(text(&output.stdout), "None\n");
+}
+
+#[test]
+fn preserves_terminal_argument_and_formatting_errors() {
+    for (source, expected) in [
+        ("import term; term.size(1)", "TypeError: too many arguments"),
+        (
+            "import term; term.raw_mode()",
+            "TypeError: too few arguments",
+        ),
+        ("import term; term.raw_mode(1)", "TypeError: expected bool"),
+        (
+            "import term; term.cursor_pos('x', 0)",
+            "TypeError: x must be int",
+        ),
+        (
+            "import term; term.cursor_pos(0, 'y')",
+            "TypeError: y must be int",
+        ),
+        (
+            "import term; term.write(1)",
+            "TypeError: text must be a string",
+        ),
+        (
+            "import term; term.cursor_pos(9223372036854775807, 9223372036854775807)",
+            "RuntimeError: failed to format cursor position",
+        ),
+        (
+            "import term; term.cursor_up(-9223372036854775807 - 1)",
+            "RuntimeError: failed to format cursor move",
+        ),
+        (
+            "import term; term.raw_mode(True)",
+            "RuntimeError: failed to read terminal settings",
+        ),
+    ] {
+        let output = run(source, b"");
+        assert_eq!(output.status.code(), Some(1), "{}", diagnostic(&output));
+        assert!(
+            text(&output.stdout).contains(expected),
+            "{}",
+            diagnostic(&output)
+        );
+        assert!(text(&output.stderr).contains("Python execution failed"));
+    }
+
+    let output = run("import term; assert term.raw_mode(False) is None", b"");
+    assert!(output.status.success(), "{}", diagnostic(&output));
+}
+
+#[test]
+fn restores_terminal_settings_when_the_vm_exits() {
+    let (master, slave) = open_pty();
+    let original = terminal_settings(slave.0);
+    // SAFETY: duplicating a valid descriptor creates an independently owned
+    // descriptor, which `File` closes after the child has inherited it.
+    let child_stdin = unsafe { libc::dup(slave.0) };
+    assert!(child_stdin >= 0, "duplicate PTY slave");
+    // SAFETY: `child_stdin` is a newly duplicated, owned descriptor.
+    let child_stdin = unsafe { File::from_raw_fd(child_stdin) };
+
+    let child = Command::new(env!("CARGO_BIN_EXE_pocketpy-ucharm-rs"))
+        .args([
+            "-c",
+            "import term; term.raw_mode(True)\nwhile term.read_key() is None:\n    pass",
+        ])
+        .stdin(Stdio::from(child_stdin))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start runtime on a PTY");
+
+    let mut raw_was_observed = false;
+    for _ in 0..100 {
+        let current = terminal_settings(slave.0);
+        if current.c_lflag & (libc::ECHO | libc::ICANON | libc::ISIG | libc::IEXTEN) == 0 {
+            raw_was_observed = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+    assert!(raw_was_observed, "child never enabled raw mode");
+
+    // SAFETY: `master` is a valid PTY descriptor and the single-byte buffer is
+    // alive for the duration of the write.
+    assert_eq!(unsafe { libc::write(master.0, b"x".as_ptr().cast(), 1) }, 1);
+    let output = child.wait_with_output().expect("wait for PTY runtime");
+    assert!(output.status.success(), "{}", diagnostic(&output));
+
+    let restored = terminal_settings(slave.0);
+    assert_eq!(restored.c_iflag, original.c_iflag);
+    assert_eq!(restored.c_oflag, original.c_oflag);
+    assert_eq!(restored.c_cflag, original.c_cflag);
+    assert_eq!(restored.c_lflag, original.c_lflag);
+    assert_eq!(restored.c_cc, original.c_cc);
+}
+
+fn run(source: &str, input: &[u8]) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_pocketpy-ucharm-rs"))
+        .args(["-c", source])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start Rust PocketPy runtime");
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(input)
+        .expect("write test input");
+    child.wait_with_output().expect("run Rust PocketPy runtime")
+}
+
+fn text(output: &impl AsRef<[u8]>) -> String {
+    String::from_utf8_lossy(output.as_ref()).into_owned()
+}
+
+fn diagnostic(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        text(&output.stdout),
+        text(&output.stderr)
+    )
+}
+
+struct FileDescriptor(libc::c_int);
+
+impl Drop for FileDescriptor {
+    fn drop(&mut self) {
+        // SAFETY: this wrapper uniquely owns the descriptor.
+        unsafe { libc::close(self.0) };
+    }
+}
+
+fn open_pty() -> (FileDescriptor, FileDescriptor) {
+    let mut master = -1;
+    let mut slave = -1;
+    // SAFETY: both descriptor pointers are writable and the optional name,
+    // settings, and window-size pointers are intentionally null.
+    let status = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        )
+    };
+    assert_eq!(status, 0, "open PTY");
+    (FileDescriptor(master), FileDescriptor(slave))
+}
+
+fn terminal_settings(descriptor: libc::c_int) -> libc::termios {
+    let mut settings = MaybeUninit::<libc::termios>::uninit();
+    // SAFETY: `settings` is writable and `descriptor` is a valid PTY.
+    let status = unsafe { libc::tcgetattr(descriptor, settings.as_mut_ptr()) };
+    assert_eq!(status, 0, "read PTY terminal settings");
+    // SAFETY: successful `tcgetattr` initialized the structure.
+    unsafe { settings.assume_init() }
+}

--- a/scripts/generate-rust-bindings.sh
+++ b/scripts/generate-rust-bindings.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 RUST_LOG=error bindgen "$project_root/pocketpy/vendor/pocketpy.h" \
-  --allowlist-function 'py_(initialize|finalize|exec|printexc|sys_setargv|newmodule|getmodule|bindfunc|retval|newint|newbool|newnone|newstrn|newlist|list_len|list_getitem|list_append|newdict|dict_getitem|dict_setitem|dict_apply|tuple_len|tuple_getitem|name|getdict|pushtmp|pop|tpobject|isidentical|istype|toint|tostrn|tobool|exception)' \
+  --allowlist-function 'py_(initialize|finalize|exec|printexc|sys_setargv|newmodule|getmodule|bindfunc|retval|newint|newbool|newnone|newstrn|newtuple|tuple_len|tuple_getitem|tuple_setitem|newlist|list_len|list_getitem|list_append|newdict|dict_getitem|dict_setitem|dict_apply|name|getdict|pushtmp|pop|tpobject|isidentical|istype|toint|tostrn|tobool|exception)' \
   --allowlist-type 'py_(CompileMode|PredefinedType|TValue|Name)' \
   --use-core \
   --no-layout-tests \


### PR DESCRIPTION
## Summary

- port the complete `term` Python module to the Rust runtime
- port the allocation-free input navigation core ahead of the interactive input state machine
- own raw terminal settings in Rust and restore them during VM teardown
- extend the generated PocketPy bindings with tuple construction
- cover terminal byte streams, key decoding, errors, and real PTY restoration

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test -p ucharm-runtime --release`
- `cargo audit` (19 dependencies, no vulnerabilities)
- `zig test runtime/ucharm/input_core.zig` (5/5)
- `target/release/ucharm-rs test --compat` (1,668/1,668)
- Zig/Rust terminal output and key-input differential tests match byte-for-byte
- macOS ARM64 and x86_64 release builds pass
- optimized runtime sizes: 617,664 bytes ARM64; 653,376 bytes x86_64 (both below 2 MB)

Linux GNU and musl release targets are covered by the PR workflow; local musl cross-linking is unavailable on this Mac.

Refs #13
