### PR TITLE
feat: port charm presentation to Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
         run: >-
           target/${{ matrix.target }}/release/pocketpy-ucharm-rs
-          -c 'import _ucharm_rust, ansi, args, input, term; assert _ucharm_rust.answer() == 42; assert ansi.fg("red") == "\x1b[31m"; assert args.count() == 1; assert input.select("", []) is None; assert input.multiselect("", []) == []; assert len(term.size()) == 2; assert term.raw_mode(False) is None'
+          -c 'import _ucharm_rust, ansi, args, charm, input, term; assert _ucharm_rust.answer() == 42; assert ansi.fg("red") == "\x1b[31m"; assert args.count() == 1; assert charm.BORDER_ROUNDED == 0; assert charm.visible_len(charm.style("界", fg="red")) == 2; assert input.select("", []) is None; assert input.multiselect("", []) == []; assert len(term.size()) == 2; assert term.raw_mode(False) is None'
       - name: Smoke-test Rust CLI
         shell: bash
         run: target/${{ matrix.target }}/release/ucharm-rs --version | grep -q "μcharm"

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -174,15 +174,18 @@ status, stdout, and stderr.
   container, type-object, and temporary-rooting surface required by native
   callbacks. Module registration is table-driven, including signature-based
   functions with defaults and keyword arguments. The complete `ansi`, `args`,
-  `term`, and interactive `input` modules are ported with Python-level behavior,
-  error, allocation-stress, byte-stream, and pseudo-terminal tests. The rooted
-  Rust `args` implementation fixes the legacy alias-key corruption and SIGSEGV
-  exposed by combined alias/default parsing. Rust owns raw terminal state and
-  restores it during VM teardown and after every interactive input path; exact
-  selection, confirmation, editing, cancellation, and password screen bytes
-  match Zig. The `charm` presentation module and its reusable TUI core are the
-  next representative Phase 4 slice. The `_ucharm_rust` probe remains
-  temporarily as an FFI smoke test while production modules cross the boundary.
+  `term`, interactive `input`, and `charm` presentation modules are ported with
+  Python-level behavior, error, allocation-stress, byte-stream, pseudo-terminal,
+  Unicode-width, and golden ANSI-output tests. The rooted Rust `args`
+  implementation fixes the legacy alias-key corruption and SIGSEGV exposed by
+  combined alias/default parsing. Rust owns raw terminal state and restores it
+  during VM teardown and after every interactive input path; exact selection,
+  confirmation, editing, cancellation, and password screen bytes match Zig.
+  The reusable Rust TUI core preserves the Zig runtime's byte-oriented width,
+  color, border, progress, spinner, and table behavior, including its historical
+  keyword-binding quirks. The representative Phase 4 module gate is now met;
+  leak/sanitizer and callback-lifetime hardening are next. The `_ucharm_rust`
+  probe remains temporarily as an FFI smoke test while that hardening finishes.
 - The initial stripped macOS ARM64 Rust spine is about 600 KB before μcharm's
   native modules and external C dependencies are added. This is an early
   feasibility signal, not a final size comparison.

--- a/crates/pocketpy-sys/src/bindings.rs
+++ b/crates/pocketpy-sys/src/bindings.rs
@@ -11,6 +11,8 @@ pub type py_Name = *mut py_OpaqueName;
 pub type py_Type = i16;
 #[doc = " A 64-bit integer type. Corresponds to `int` in python."]
 pub type py_i64 = i64;
+#[doc = " A 64-bit floating-point type. Corresponds to `float` in python."]
+pub type py_f64 = f64;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct py_TValue {
@@ -101,6 +103,10 @@ unsafe extern "C" {
     pub fn py_toint(arg1: py_Ref) -> py_i64;
 }
 unsafe extern "C" {
+    #[doc = " Convert a `float` object in python to `double`."]
+    pub fn py_tofloat(arg1: py_Ref) -> py_f64;
+}
+unsafe extern "C" {
     #[doc = " Convert a `bool` object in python to `bool`."]
     pub fn py_tobool(arg1: py_Ref) -> bool;
 }
@@ -123,6 +129,10 @@ unsafe extern "C" {
 unsafe extern "C" {
     #[doc = " Get an item from the object's `__dict__`.\n Return `NULL` if not found."]
     pub fn py_getdict(self_: py_Ref, name: py_Name) -> py_ItemRef;
+}
+unsafe extern "C" {
+    #[doc = " Set an item to the object's `__dict__`."]
+    pub fn py_setdict(self_: py_Ref, name: py_Name, val: py_Ref);
 }
 unsafe extern "C" {
     #[doc = " Pop an object from the stack."]

--- a/crates/ucharm-runtime/src/modules/ansi.rs
+++ b/crates/ucharm-runtime/src/modules/ansi.rs
@@ -60,6 +60,7 @@ pub(super) const MODULE: NativeModule = NativeModule {
     name: c"ansi",
     functions: FUNCTIONS,
     signatures: &[],
+    int_constants: &[],
 };
 
 unsafe extern "C" fn reset(argc: c_int, argv: ffi::py_StackRef) -> bool {

--- a/crates/ucharm-runtime/src/modules/args.rs
+++ b/crates/ucharm-runtime/src/modules/args.rs
@@ -47,6 +47,7 @@ pub(super) const MODULE: NativeModule = NativeModule {
     name: c"args",
     functions: FUNCTIONS,
     signatures: &[],
+    int_constants: &[],
 };
 
 fn sys_argv() -> Option<Value> {

--- a/crates/ucharm-runtime/src/modules/charm.rs
+++ b/crates/ucharm-runtime/src/modules/charm.rs
@@ -1,0 +1,580 @@
+use std::ffi::c_int;
+use std::fmt::Write as _;
+use std::io::{self, Write};
+
+use ucharm_pocketpy_sys as ffi;
+
+use super::charm_core::{self, BorderStyle};
+use crate::native::{
+    Arguments, NativeFunction, NativeIntConstant, NativeModule, NativeSignature, RootFrame, Value,
+    return_string, return_value, runtime_error, type_error, value_error,
+};
+
+const FUNCTIONS: &[NativeFunction] = &[
+    NativeFunction {
+        name: c"visible_len",
+        callback: visible_len,
+    },
+    NativeFunction {
+        name: c"success",
+        callback: success,
+    },
+    NativeFunction {
+        name: c"error",
+        callback: error,
+    },
+    NativeFunction {
+        name: c"warning",
+        callback: warning,
+    },
+    NativeFunction {
+        name: c"info",
+        callback: info,
+    },
+    NativeFunction {
+        name: c"progress_done",
+        callback: progress_done,
+    },
+    NativeFunction {
+        name: c"spinner_frame",
+        callback: spinner_frame,
+    },
+];
+
+const SIGNATURES: &[NativeSignature] = &[
+    NativeSignature {
+        signature: c"style(text, fg=None, bg=None, bold=False, dim=False, italic=False, underline=False, strikethrough=False)",
+        callback: style,
+    },
+    // These declarations intentionally preserve the production Zig binding,
+    // including its historical parameter-name mismatches with the stubs.
+    NativeSignature {
+        signature: c"box(content, title=None, border_color=None, padding=0, border_style=None)",
+        callback: box_output,
+    },
+    NativeSignature {
+        signature: c"rule(title=None, color=None, align=0, width=0)",
+        callback: rule,
+    },
+    NativeSignature {
+        signature: c"progress(current, total, label=None, width=40, color=None, elapsed=None)",
+        callback: progress,
+    },
+    NativeSignature {
+        signature: c"spinner(frame, message=None, color=None)",
+        callback: spinner,
+    },
+    NativeSignature {
+        signature: c"table(rows, headers=False, border='square', border_color=None)",
+        callback: table,
+    },
+];
+
+const INT_CONSTANTS: &[NativeIntConstant] = &[
+    NativeIntConstant {
+        name: c"BORDER_ROUNDED",
+        value: charm_core::BORDER_ROUNDED,
+    },
+    NativeIntConstant {
+        name: c"BORDER_SQUARE",
+        value: charm_core::BORDER_SQUARE,
+    },
+    NativeIntConstant {
+        name: c"BORDER_DOUBLE",
+        value: charm_core::BORDER_DOUBLE,
+    },
+    NativeIntConstant {
+        name: c"BORDER_HEAVY",
+        value: charm_core::BORDER_HEAVY,
+    },
+    NativeIntConstant {
+        name: c"BORDER_NONE",
+        value: charm_core::BORDER_NONE,
+    },
+    NativeIntConstant {
+        name: c"ALIGN_LEFT",
+        value: 0,
+    },
+    NativeIntConstant {
+        name: c"ALIGN_RIGHT",
+        value: 1,
+    },
+    NativeIntConstant {
+        name: c"ALIGN_CENTER",
+        value: 2,
+    },
+];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"charm",
+    functions: FUNCTIONS,
+    signatures: SIGNATURES,
+    int_constants: INT_CONSTANTS,
+};
+
+fn write_output(bytes: &[u8]) {
+    let mut output = io::stdout().lock();
+    let _ = output.write_all(bytes);
+    let _ = output.flush();
+}
+
+fn return_none() -> bool {
+    let mut roots = RootFrame::new();
+    let none = roots.none();
+    return_value(none)
+}
+
+fn legacy_c_string(mut value: String) -> String {
+    if let Some(nul) = value.find('\0') {
+        value.truncate(nul);
+    }
+    value
+}
+
+fn optional_string(arguments: &Arguments, index: usize, c_string: bool) -> Option<String> {
+    let value = arguments.get(index)?;
+    if value.is_none() {
+        return None;
+    }
+    let value = value.string()?;
+    Some(if c_string {
+        legacy_c_string(value)
+    } else {
+        value
+    })
+}
+
+fn style_prefix(color: Option<&str>) -> (String, &'static str) {
+    let start = charm_core::style_code(color, None, false, false, false, false, false);
+    if start.is_empty() {
+        (start, "")
+    } else {
+        (start, "\x1b[0m")
+    }
+}
+
+unsafe extern "C" fn visible_len(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return false;
+    }
+    let Some(text) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"text must be a string");
+    };
+    if text.len() >= 4096 {
+        return value_error(c"text too long");
+    }
+    let mut roots = RootFrame::new();
+    let length = roots.integer(charm_core::visible_len(&text) as i64);
+    return_value(length)
+}
+
+unsafe extern "C" fn style(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(text) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"text must be a string");
+    };
+    let foreground = optional_string(&arguments, 1, true);
+    let background = optional_string(&arguments, 2, true);
+    let prefix = charm_core::style_code(
+        foreground.as_deref(),
+        background.as_deref(),
+        arguments.get(3).and_then(Value::boolean).unwrap_or(false),
+        arguments.get(4).and_then(Value::boolean).unwrap_or(false),
+        arguments.get(5).and_then(Value::boolean).unwrap_or(false),
+        arguments.get(6).and_then(Value::boolean).unwrap_or(false),
+        arguments.get(7).and_then(Value::boolean).unwrap_or(false),
+    );
+    if prefix.is_empty() {
+        return return_string(&text);
+    }
+    return_string(&format!("{prefix}{text}\x1b[0m"))
+}
+
+unsafe extern "C" fn box_output(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(content) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"content must be a string");
+    };
+    let title = optional_string(&arguments, 1, true);
+    let border = optional_string(&arguments, 2, true).unwrap_or_else(|| "rounded".to_owned());
+    let border_color = optional_string(&arguments, 3, true);
+    let padding = arguments.get(4).and_then(Value::integer).unwrap_or(1) as u32 as usize;
+    if padding > 1_000_000 {
+        return runtime_error(c"box is too large");
+    }
+
+    let chars = charm_core::box_chars(BorderStyle::for_box(&border));
+    let maximum_width = content
+        .split('\n')
+        .map(charm_core::visible_len)
+        .max()
+        .unwrap_or(0);
+    let title_length = title.as_ref().map_or(0, String::len);
+    let title_width = if title.is_some() {
+        title_length.saturating_add(4)
+    } else {
+        0
+    };
+    let content_width = maximum_width.max(title_width.saturating_sub(2));
+    let Some(inner_width) = content_width.checked_add(padding.saturating_mul(2)) else {
+        return runtime_error(c"box is too large");
+    };
+    if inner_width > 1_000_000 {
+        return runtime_error(c"box is too large");
+    }
+
+    let (color_start, color_end) = style_prefix(border_color.as_deref());
+    let mut output = String::new();
+    if let Some(title) = title.as_deref() {
+        output.push_str(&color_start);
+        output.push_str(chars.tl);
+        output.push_str(chars.h);
+        output.push_str(color_end);
+        output.push_str("\x1b[1m ");
+        output.push_str(title);
+        output.push_str(" \x1b[0m");
+        output.push_str(&color_start);
+        output.push_str(&charm_core::repeat(
+            chars.h,
+            inner_width.saturating_sub(title_length.saturating_add(3)),
+        ));
+        output.push_str(chars.tr);
+        output.push_str(color_end);
+        output.push('\n');
+    } else {
+        output.push_str(&color_start);
+        output.push_str(chars.tl);
+        output.push_str(&charm_core::repeat(chars.h, inner_width));
+        output.push_str(chars.tr);
+        output.push_str(color_end);
+        output.push('\n');
+    }
+
+    let side_padding = " ".repeat(padding);
+    for line in content.split('\n') {
+        let line = legacy_c_string(line.to_owned());
+        output.push_str(&color_start);
+        output.push_str(chars.v);
+        output.push_str(color_end);
+        output.push_str(&side_padding);
+        output.push_str(&charm_core::pad_left(&line, content_width));
+        output.push_str(&side_padding);
+        output.push_str(&color_start);
+        output.push_str(chars.v);
+        output.push_str(color_end);
+        output.push('\n');
+    }
+
+    output.push_str(&color_start);
+    output.push_str(chars.bl);
+    output.push_str(&charm_core::repeat(chars.h, inner_width));
+    output.push_str(chars.br);
+    output.push_str(color_end);
+    output.push('\n');
+    write_output(output.as_bytes());
+    return_none()
+}
+
+unsafe extern "C" fn rule(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let title = optional_string(&arguments, 0, true);
+    let character = optional_string(&arguments, 1, true).unwrap_or_else(|| "─".to_owned());
+    let color = optional_string(&arguments, 2, true);
+    let width = arguments
+        .get(3)
+        .and_then(Value::integer)
+        .unwrap_or(80)
+        .clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
+    let (color_start, color_end) = style_prefix(color.as_deref());
+    let mut output = String::new();
+    if let Some(title) = title.as_deref() {
+        let title_length = i32::try_from(title.len()).unwrap_or(i32::MAX);
+        let side = ((width.saturating_sub(title_length).saturating_sub(2)) / 2).max(0);
+        output.push_str(&color_start);
+        output.push_str(&charm_core::repeat(&character, side as usize));
+        output.push_str(color_end);
+        output.push(' ');
+        output.push_str(title);
+        output.push(' ');
+        let remaining = width
+            .saturating_sub(side)
+            .saturating_sub(title_length)
+            .saturating_sub(2)
+            .max(0);
+        output.push_str(&color_start);
+        output.push_str(&charm_core::repeat(&character, remaining as usize));
+        output.push_str(color_end);
+        output.push('\n');
+    } else {
+        output.push_str(&color_start);
+        output.push_str(&charm_core::repeat(&character, width.max(0) as usize));
+        output.push_str(color_end);
+        output.push('\n');
+    }
+    write_output(output.as_bytes());
+    return_none()
+}
+
+fn status_message(
+    argc: c_int,
+    argv: ffi::py_StackRef,
+    color: &'static str,
+    symbol: &'static str,
+) -> bool {
+    // SAFETY: called only from PocketPy callbacks with an active argument stack.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return false;
+    }
+    let Some(message) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"message must be a string");
+    };
+    write_output(format!("\x1b[1;{color}m{symbol} \x1b[0m{message}\n").as_bytes());
+    return_none()
+}
+
+unsafe extern "C" fn success(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    status_message(argc, argv, "32", charm_core::SYMBOL_SUCCESS)
+}
+
+unsafe extern "C" fn error(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    status_message(argc, argv, "31", charm_core::SYMBOL_ERROR)
+}
+
+unsafe extern "C" fn warning(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    status_message(argc, argv, "33", charm_core::SYMBOL_WARNING)
+}
+
+unsafe extern "C" fn info(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    status_message(argc, argv, "34", charm_core::SYMBOL_INFO)
+}
+
+unsafe extern "C" fn progress(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(current) = arguments.get(0).and_then(Value::integer) else {
+        return type_error(c"current must be int");
+    };
+    let Some(total) = arguments.get(1).and_then(Value::integer) else {
+        return type_error(c"total must be int");
+    };
+    let label = optional_string(&arguments, 2, true);
+    let width = arguments.get(3).and_then(Value::integer).unwrap_or(40) as u32;
+    if width > 1_000_000 {
+        return runtime_error(c"progress bar is too large");
+    }
+    let color = optional_string(&arguments, 4, true);
+    let elapsed = arguments.get(5).and_then(|value| {
+        if value.is_none() {
+            None
+        } else {
+            value.number()
+        }
+    });
+    let (color_start, color_end) = style_prefix(color.as_deref());
+    let mut output = String::from("\r");
+    if let Some(label) = label {
+        output.push_str(&label);
+        output.push(' ');
+    }
+    output.push_str(&color_start);
+    output.push_str(&charm_core::progress_bar(
+        current as u32,
+        total as u32,
+        width,
+    ));
+    output.push_str(color_end);
+    output.push(' ');
+    output.push_str(&charm_core::percent_string(current as u32, total as u32));
+    if let Some(elapsed) = elapsed {
+        let _ = write!(output, "  {}s", charm_core::elapsed_string(elapsed));
+    }
+    output.push_str("\x1b[K");
+    write_output(output.as_bytes());
+    return_none()
+}
+
+unsafe extern "C" fn progress_done(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(0, 0) {
+        return false;
+    }
+    write_output(b"\n");
+    return_none()
+}
+
+unsafe extern "C" fn spinner_frame(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return false;
+    }
+    let Some(index) = arguments.get(0).and_then(Value::integer) else {
+        return type_error(c"index must be int");
+    };
+    return_string(charm_core::spinner_frame(index as u32))
+}
+
+unsafe extern "C" fn spinner(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(index) = arguments.get(0).and_then(Value::integer) else {
+        return type_error(c"index must be int");
+    };
+    let message = optional_string(&arguments, 1, false);
+    let color = optional_string(&arguments, 2, true);
+    let (color_start, color_end) = style_prefix(color.as_deref());
+    let mut output = format!(
+        "\r{color_start}{}{color_end}",
+        charm_core::spinner_frame(index as u32)
+    );
+    if let Some(message) = message {
+        output.push(' ');
+        output.push_str(&message);
+    }
+    output.push_str("\x1b[K");
+    write_output(output.as_bytes());
+    return_none()
+}
+
+fn horizontal_line(
+    output: &mut String,
+    edges: (&str, &str, &str),
+    horizontal: &str,
+    widths: &[usize],
+    color_start: &str,
+    color_end: &str,
+) {
+    let (left, middle, right) = edges;
+    output.push_str(color_start);
+    output.push_str(left);
+    for (index, width) in widths.iter().enumerate() {
+        output.push_str(&charm_core::repeat(horizontal, width + 2));
+        if index + 1 < widths.len() {
+            output.push_str(middle);
+        }
+    }
+    output.push_str(right);
+    output.push_str(color_end);
+    output.push('\n');
+}
+
+unsafe extern "C" fn table(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    // SAFETY: PocketPy supplies an active argument stack to this callback.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(rows) = arguments.get(0) else {
+        return type_error(c"rows must be a list");
+    };
+    let Some(row_count) = rows.list_len() else {
+        return type_error(c"rows must be a list");
+    };
+    if row_count == 0 {
+        return return_none();
+    }
+    let Some(first_row) = rows.list_item(0) else {
+        return type_error(c"rows must not be empty");
+    };
+    let Some(column_count) = first_row.list_len() else {
+        return type_error(c"each row must be a list");
+    };
+    if column_count == 0 {
+        return return_none();
+    }
+
+    let has_headers = arguments.get(1).and_then(Value::boolean).unwrap_or(false);
+    let border = optional_string(&arguments, 2, false).unwrap_or_else(|| "square".to_owned());
+    let border_color = optional_string(&arguments, 3, true);
+    let chars = charm_core::table_chars(BorderStyle::for_table(&border));
+    let actual_columns = column_count.min(32);
+    let mut widths = vec![0_usize; actual_columns];
+    for row_index in 0..row_count {
+        let Some(row) = rows.list_item(row_index) else {
+            continue;
+        };
+        let Some(row_length) = row.list_len() else {
+            continue;
+        };
+        for (column_index, width) in widths
+            .iter_mut()
+            .enumerate()
+            .take(row_length.min(actual_columns))
+        {
+            let cell = row
+                .list_item(column_index)
+                .and_then(Value::string)
+                .unwrap_or_default();
+            *width = (*width).max(charm_core::visible_len(&cell));
+        }
+    }
+
+    let (color_start, color_end) = style_prefix(border_color.as_deref());
+    let mut output = String::new();
+    horizontal_line(
+        &mut output,
+        (chars.tl, chars.th, chars.tr),
+        chars.h,
+        &widths,
+        &color_start,
+        color_end,
+    );
+    for row_index in 0..row_count {
+        let Some(row) = rows.list_item(row_index) else {
+            continue;
+        };
+        let Some(row_length) = row.list_len() else {
+            continue;
+        };
+        output.push_str(&color_start);
+        output.push_str(chars.v);
+        output.push_str(color_end);
+        for (column_index, width) in widths.iter().enumerate() {
+            output.push(' ');
+            let cell = if column_index < row_length {
+                row.list_item(column_index)
+                    .and_then(Value::string)
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+            if has_headers && row_index == 0 {
+                output.push_str("\x1b[1m");
+            }
+            output.push_str(&cell);
+            if has_headers && row_index == 0 {
+                output.push_str("\x1b[0m");
+            }
+            output.push_str(&" ".repeat(width.saturating_sub(charm_core::visible_len(&cell))));
+            output.push(' ');
+            output.push_str(&color_start);
+            output.push_str(chars.v);
+            output.push_str(color_end);
+        }
+        output.push('\n');
+        if has_headers && row_index == 0 && row_count > 1 {
+            horizontal_line(
+                &mut output,
+                (chars.lv, chars.cross, chars.rv),
+                chars.h,
+                &widths,
+                &color_start,
+                color_end,
+            );
+        }
+    }
+    horizontal_line(
+        &mut output,
+        (chars.bl, chars.bh, chars.br),
+        chars.h,
+        &widths,
+        &color_start,
+        color_end,
+    );
+    write_output(output.as_bytes());
+    return_none()
+}

--- a/crates/ucharm-runtime/src/modules/charm_core.rs
+++ b/crates/ucharm-runtime/src/modules/charm_core.rs
@@ -1,0 +1,374 @@
+pub(super) const BORDER_ROUNDED: i64 = 0;
+pub(super) const BORDER_SQUARE: i64 = 1;
+pub(super) const BORDER_DOUBLE: i64 = 2;
+pub(super) const BORDER_HEAVY: i64 = 3;
+pub(super) const BORDER_NONE: i64 = 4;
+
+pub(super) const SYMBOL_SUCCESS: &str = "✓";
+pub(super) const SYMBOL_ERROR: &str = "✗";
+pub(super) const SYMBOL_WARNING: &str = "⚠";
+pub(super) const SYMBOL_INFO: &str = "ℹ";
+
+const PROGRESS_FILL: &str = "█";
+const PROGRESS_EMPTY: &str = "░";
+const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+#[derive(Clone, Copy)]
+pub(super) enum BorderStyle {
+    Rounded,
+    Square,
+    Double,
+    Heavy,
+    None,
+}
+
+impl BorderStyle {
+    pub fn for_box(value: &str) -> Self {
+        match value {
+            "square" => Self::Square,
+            "double" => Self::Double,
+            "heavy" => Self::Heavy,
+            "none" => Self::None,
+            _ => Self::Rounded,
+        }
+    }
+
+    pub fn for_table(value: &str) -> Self {
+        match value {
+            "rounded" => Self::Rounded,
+            "double" => Self::Double,
+            "heavy" => Self::Heavy,
+            "none" => Self::None,
+            _ => Self::Square,
+        }
+    }
+}
+
+pub(super) struct BoxChars {
+    pub tl: &'static str,
+    pub tr: &'static str,
+    pub bl: &'static str,
+    pub br: &'static str,
+    pub h: &'static str,
+    pub v: &'static str,
+}
+
+pub(super) fn box_chars(style: BorderStyle) -> BoxChars {
+    match style {
+        BorderStyle::Rounded => BoxChars {
+            tl: "╭",
+            tr: "╮",
+            bl: "╰",
+            br: "╯",
+            h: "─",
+            v: "│",
+        },
+        BorderStyle::Square => BoxChars {
+            tl: "┌",
+            tr: "┐",
+            bl: "└",
+            br: "┘",
+            h: "─",
+            v: "│",
+        },
+        BorderStyle::Double => BoxChars {
+            tl: "╔",
+            tr: "╗",
+            bl: "╚",
+            br: "╝",
+            h: "═",
+            v: "║",
+        },
+        BorderStyle::Heavy => BoxChars {
+            tl: "┏",
+            tr: "┓",
+            bl: "┗",
+            br: "┛",
+            h: "━",
+            v: "┃",
+        },
+        BorderStyle::None => BoxChars {
+            tl: " ",
+            tr: " ",
+            bl: " ",
+            br: " ",
+            h: " ",
+            v: " ",
+        },
+    }
+}
+
+pub(super) struct TableChars {
+    pub h: &'static str,
+    pub v: &'static str,
+    pub tl: &'static str,
+    pub tr: &'static str,
+    pub bl: &'static str,
+    pub br: &'static str,
+    pub th: &'static str,
+    pub bh: &'static str,
+    pub lv: &'static str,
+    pub rv: &'static str,
+    pub cross: &'static str,
+}
+
+pub(super) fn table_chars(style: BorderStyle) -> TableChars {
+    let (h, v, th, bh, lv, rv, cross) = match style {
+        BorderStyle::Double => ("═", "║", "╦", "╩", "╠", "╣", "╬"),
+        BorderStyle::Heavy => ("━", "┃", "┳", "┻", "┣", "┫", "╋"),
+        BorderStyle::None => (" ", " ", " ", " ", " ", " ", " "),
+        BorderStyle::Rounded | BorderStyle::Square => ("─", "│", "┬", "┴", "├", "┤", "┼"),
+    };
+    let (tl, tr, bl, br) = match style {
+        BorderStyle::Rounded => ("╭", "╮", "╰", "╯"),
+        BorderStyle::Square => ("┌", "┐", "└", "┘"),
+        BorderStyle::Double => ("╔", "╗", "╚", "╝"),
+        BorderStyle::Heavy => ("┏", "┓", "┗", "┛"),
+        BorderStyle::None => (" ", " ", " ", " "),
+    };
+    TableChars {
+        h,
+        v,
+        tl,
+        tr,
+        bl,
+        br,
+        th,
+        bh,
+        lv,
+        rv,
+        cross,
+    }
+}
+
+/// Mirrors the legacy byte-oriented width algorithm, including its treatment
+/// of every three- and four-byte UTF-8 scalar as double-width.
+pub(super) fn visible_len(value: &str) -> usize {
+    let bytes = value.as_bytes();
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    let mut index = 0;
+    let mut length = 0;
+    while index < end {
+        if bytes[index] == 0x1b && bytes.get(index + 1) == Some(&b'[') {
+            index += 2;
+            while index < end && !matches!(bytes[index], b'm' | b'H' | b'J' | b'K') {
+                index += 1;
+            }
+            if index < end {
+                index += 1;
+            }
+        } else {
+            let byte = bytes[index];
+            if byte < 0x80 {
+                length += 1;
+                index += 1;
+            } else if byte < 0xe0 {
+                length += 1;
+                index += 2;
+            } else if byte < 0xf0 {
+                length += 2;
+                index += 3;
+            } else {
+                length += 2;
+                index += 4;
+            }
+        }
+    }
+    length
+}
+
+pub(super) fn color_code(name: &str) -> Option<i32> {
+    match name {
+        "black" => Some(30),
+        "red" => Some(31),
+        "green" => Some(32),
+        "yellow" => Some(33),
+        "blue" => Some(34),
+        "magenta" => Some(35),
+        "cyan" => Some(36),
+        "white" => Some(37),
+        "gray" | "grey" => Some(90),
+        _ => None,
+    }
+}
+
+pub(super) fn parse_hex(value: &str) -> Option<(u8, u8, u8)> {
+    let digits = value.strip_prefix('#')?;
+    let digits = digits.as_bytes();
+    let nibble = |value: u8| match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    };
+    match digits.len() {
+        3 => {
+            let r = nibble(digits[0])?;
+            let g = nibble(digits[1])?;
+            let b = nibble(digits[2])?;
+            Some((r * 17, g * 17, b * 17))
+        }
+        6 => {
+            let r = nibble(digits[0])? * 16 + nibble(digits[1])?;
+            let g = nibble(digits[2])? * 16 + nibble(digits[3])?;
+            let b = nibble(digits[4])? * 16 + nibble(digits[5])?;
+            Some((r, g, b))
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn style_code(
+    foreground: Option<&str>,
+    background: Option<&str>,
+    bold: bool,
+    dim: bool,
+    italic: bool,
+    underline: bool,
+    strikethrough: bool,
+) -> String {
+    let mut codes = Vec::new();
+    if bold {
+        codes.push("1".to_owned());
+    }
+    if dim {
+        codes.push("2".to_owned());
+    }
+    if italic {
+        codes.push("3".to_owned());
+    }
+    if underline {
+        codes.push("4".to_owned());
+    }
+    if strikethrough {
+        codes.push("9".to_owned());
+    }
+    if let Some(foreground) = foreground {
+        if let Some(code) = color_code(foreground) {
+            codes.push(code.to_string());
+        } else if let Some((r, g, b)) = parse_hex(foreground) {
+            codes.push(format!("38;2;{r};{g};{b}"));
+        }
+    }
+    if let Some(background) = background {
+        if let Some(code) = color_code(background) {
+            codes.push((code + 10).to_string());
+        } else if let Some((r, g, b)) = parse_hex(background) {
+            codes.push(format!("48;2;{r};{g};{b}"));
+        }
+    }
+    if codes.is_empty() {
+        String::new()
+    } else {
+        format!("\x1b[{}m", codes.join(";"))
+    }
+}
+
+pub(super) fn repeat(pattern: &str, count: usize) -> String {
+    pattern.repeat(count)
+}
+
+pub(super) fn pad_left(value: &str, width: usize) -> String {
+    let visible = visible_len(value);
+    if visible >= width {
+        value.to_owned()
+    } else {
+        format!("{value}{}", " ".repeat(width - visible))
+    }
+}
+
+pub(super) fn progress_bar(current: u32, total: u32, width: u32) -> String {
+    if total == 0 || width == 0 {
+        return String::new();
+    }
+    let filled = width.min(width.wrapping_mul(current) / total);
+    format!(
+        "{}{}",
+        PROGRESS_FILL.repeat(filled as usize),
+        PROGRESS_EMPTY.repeat((width - filled) as usize)
+    )
+}
+
+pub(super) fn percent_string(current: u32, total: u32) -> String {
+    if total == 0 {
+        return "0%".to_owned();
+    }
+    let value = 100_u32.wrapping_mul(current) / total;
+    let mut output = String::new();
+    if value >= 100 {
+        output.push(char::from(b'0' + ((value / 100) % 10) as u8));
+    }
+    if value >= 10 {
+        output.push(char::from(b'0' + ((value / 10) % 10) as u8));
+    }
+    output.push(char::from(b'0' + (value % 10) as u8));
+    output.push('%');
+    output
+}
+
+pub(super) fn spinner_frame(index: u32) -> &'static str {
+    SPINNER_FRAMES[index as usize % SPINNER_FRAMES.len()]
+}
+
+pub(super) fn elapsed_string(value: f64) -> String {
+    // Zig's decimal formatter rounds midpoint values away from zero, while
+    // Rust's formatting uses round-to-even. Round explicitly for parity.
+    format!("{:.1}", (value * 10.0).round() / 10.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BorderStyle, box_chars, color_code, elapsed_string, pad_left, parse_hex, percent_string,
+        progress_bar, spinner_frame, style_code, table_chars, visible_len,
+    };
+
+    #[test]
+    fn visible_width_vectors_match_zig() {
+        assert_eq!(visible_len("hello"), 5);
+        assert_eq!(visible_len(""), 0);
+        assert_eq!(visible_len("\x1b[31mhello\x1b[0m"), 5);
+        assert_eq!(visible_len("é"), 1);
+        assert_eq!(visible_len("界"), 2);
+        assert_eq!(visible_len("🙂"), 2);
+        assert_eq!(visible_len("a\0ignored"), 1);
+    }
+
+    #[test]
+    fn colors_and_hex_vectors_match_zig() {
+        assert_eq!(color_code("red"), Some(31));
+        assert_eq!(color_code("green"), Some(32));
+        assert_eq!(color_code("purple"), None);
+        assert_eq!(parse_hex("#ff5500"), Some((255, 85, 0)));
+        assert_eq!(parse_hex("#abc"), Some((170, 187, 204)));
+        assert_eq!(parse_hex("#ggg"), None);
+        assert_eq!(
+            style_code(Some("red"), Some("#abc"), true, false, false, true, false),
+            "\x1b[1;4;31;48;2;170;187;204m"
+        );
+    }
+
+    #[test]
+    fn progress_and_spinner_vectors_match_zig() {
+        assert_eq!(progress_bar(5, 10, 10), "█████░░░░░");
+        assert_eq!(progress_bar(1, 0, 10), "");
+        assert_eq!(percent_string(5, 10), "50%");
+        assert_eq!(percent_string(1, 0), "0%");
+        assert_eq!(percent_string(150, 10), "500%");
+        assert_eq!(spinner_frame(0), "⠋");
+        assert_eq!(spinner_frame(10), "⠋");
+        assert_eq!(elapsed_string(1.25), "1.3");
+        assert_eq!(elapsed_string(-1.25), "-1.3");
+    }
+
+    #[test]
+    fn layout_vectors_match_zig() {
+        assert_eq!(pad_left("x", 3), "x  ");
+        assert_eq!(pad_left("界", 3), "界 ");
+        assert_eq!(box_chars(BorderStyle::Rounded).tl, "╭");
+        assert_eq!(table_chars(BorderStyle::Double).cross, "╬");
+    }
+}

--- a/crates/ucharm-runtime/src/modules/input.rs
+++ b/crates/ucharm-runtime/src/modules/input.rs
@@ -52,6 +52,7 @@ pub(super) const MODULE: NativeModule = NativeModule {
     name: c"input",
     functions: FUNCTIONS,
     signatures: SIGNATURES,
+    int_constants: &[],
 };
 
 struct InputState {

--- a/crates/ucharm-runtime/src/modules/mod.rs
+++ b/crates/ucharm-runtime/src/modules/mod.rs
@@ -1,13 +1,21 @@
 mod ansi;
 mod ansi_core;
 mod args;
+mod charm;
+mod charm_core;
 mod input;
 mod term;
 mod term_core;
 
 use crate::native::{NativeModule, register_modules};
 
-const MODULES: &[NativeModule] = &[ansi::MODULE, args::MODULE, input::MODULE, term::MODULE];
+const MODULES: &[NativeModule] = &[
+    ansi::MODULE,
+    args::MODULE,
+    charm::MODULE,
+    input::MODULE,
+    term::MODULE,
+];
 
 pub(crate) fn register_all() {
     register_modules(MODULES);

--- a/crates/ucharm-runtime/src/modules/term.rs
+++ b/crates/ucharm-runtime/src/modules/term.rs
@@ -73,6 +73,7 @@ pub(super) const MODULE: NativeModule = NativeModule {
     name: c"term",
     functions: FUNCTIONS,
     signatures: &[],
+    int_constants: &[],
 };
 
 #[derive(Default)]

--- a/crates/ucharm-runtime/src/native.rs
+++ b/crates/ucharm-runtime/src/native.rs
@@ -16,10 +16,16 @@ pub(crate) struct NativeSignature {
     pub callback: Callback,
 }
 
+pub(crate) struct NativeIntConstant {
+    pub name: &'static CStr,
+    pub value: i64,
+}
+
 pub(crate) struct NativeModule {
     pub name: &'static CStr,
     pub functions: &'static [NativeFunction],
     pub signatures: &'static [NativeSignature],
+    pub int_constants: &'static [NativeIntConstant],
 }
 
 pub(crate) fn register_modules(modules: &[NativeModule]) {
@@ -34,6 +40,12 @@ pub(crate) fn register_modules(modules: &[NativeModule]) {
             }
             for function in module.signatures {
                 ffi::py_bind(object, function.signature.as_ptr(), Some(function.callback));
+            }
+            for constant in module.int_constants {
+                let value = ffi::py_pushtmp();
+                ffi::py_newint(value, constant.value);
+                ffi::py_setdict(object, ffi::py_name(constant.name.as_ptr()), value);
+                ffi::py_pop();
             }
         }
     }
@@ -106,6 +118,18 @@ impl Value {
         }
         // SAFETY: the exact type check above establishes a boolean value.
         Some(unsafe { ffi::py_tobool(self.raw) })
+    }
+
+    pub fn number(self) -> Option<f64> {
+        if self.is_type(ffi::py_PredefinedType_tp_int) {
+            // SAFETY: the exact type check above establishes an integer value.
+            return Some(unsafe { ffi::py_toint(self.raw) } as f64);
+        }
+        if self.is_type(ffi::py_PredefinedType_tp_float) {
+            // SAFETY: the exact type check above establishes a float value.
+            return Some(unsafe { ffi::py_tofloat(self.raw) });
+        }
+        None
     }
 
     pub fn is_none(self) -> bool {
@@ -385,6 +409,18 @@ pub(crate) fn runtime_error(message: &'static CStr) -> bool {
     unsafe {
         ffi::py_exception(
             ffi::py_PredefinedType_tp_RuntimeError as ffi::py_Type,
+            c"%s".as_ptr(),
+            message.as_ptr(),
+        )
+    }
+}
+
+pub(crate) fn value_error(message: &'static CStr) -> bool {
+    // SAFETY: the VM is active during a callback. The format string and message
+    // have static storage and match PocketPy's `%s` vararg contract.
+    unsafe {
+        ffi::py_exception(
+            ffi::py_PredefinedType_tp_ValueError as ffi::py_Type,
             c"%s".as_ptr(),
             message.as_ptr(),
         )

--- a/crates/ucharm-runtime/tests/charm.rs
+++ b/crates/ucharm-runtime/tests/charm.rs
@@ -1,0 +1,149 @@
+use std::process::{Command, Output};
+
+#[test]
+fn exposes_constants_styles_and_legacy_visible_width() {
+    let output = run("import charm\n\
+print([charm.BORDER_ROUNDED, charm.BORDER_SQUARE, charm.BORDER_DOUBLE, charm.BORDER_HEAVY, charm.BORDER_NONE, charm.ALIGN_LEFT, charm.ALIGN_RIGHT, charm.ALIGN_CENTER])\n\
+print(repr(charm.style('Hi', fg='red', bg='#abc', bold=True, underline=True)))\n\
+print(repr(charm.style('x', fg='purple')))\n\
+print(charm.visible_len('\\x1b[31mé界🙂\\x1b[0m'))");
+
+    assert!(output.status.success(), "{}", text(&output.stderr));
+    assert_eq!(
+        text(&output.stdout),
+        "[0, 1, 2, 3, 4, 0, 1, 2]\n\
+'\\x1b[1;4;31;48;2;170;187;204mHi\\x1b[0m'\n\
+'x'\n\
+5\n"
+    );
+    assert_eq!(text(&output.stderr), "");
+}
+
+#[test]
+fn renders_status_messages_and_rules_byte_for_byte() {
+    let output = run("import charm\n\
+charm.success('ok')\n\
+charm.error('bad')\n\
+charm.warning('hmm')\n\
+charm.info('note')\n\
+charm.rule()\n\
+charm.rule('Title', width=12)\n\
+charm.rule('T', color='=', align='red', width=8)");
+
+    assert!(output.status.success(), "{}", text(&output.stderr));
+    assert_eq!(
+        output.stdout,
+        b"\x1b[1;32m\xe2\x9c\x93 \x1b[0mok\n\
+\x1b[1;31m\xe2\x9c\x97 \x1b[0mbad\n\
+\x1b[1;33m\xe2\x9a\xa0 \x1b[0mhmm\n\
+\x1b[1;34m\xe2\x84\xb9 \x1b[0mnote\n\
+\n\
+\xe2\x94\x80\xe2\x94\x80 Title \xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n\
+\x1b[31m==\x1b[0m T \x1b[31m===\x1b[0m\n"
+    );
+}
+
+#[test]
+fn renders_boxes_and_preserves_the_zig_keyword_binding() {
+    let titled = run("import charm; charm.box('Hi', title='T')");
+    assert!(titled.status.success(), "{}", text(&titled.stderr));
+    assert_eq!(
+        text(&titled.stdout),
+        "╭─\x1b[1m T \x1b[0m─╮\n│ Hi  │\n╰─────╯\n"
+    );
+
+    // The production Zig signature names these slots differently from the
+    // callback. Keep that observable behavior until a deliberate API break.
+    let keyword_bound = run(
+        "import charm; charm.box('Hi', title='T', border_color='double', padding='red', border_style=2)",
+    );
+    assert!(
+        keyword_bound.status.success(),
+        "{}",
+        text(&keyword_bound.stderr)
+    );
+    assert_eq!(
+        text(&keyword_bound.stdout),
+        "\x1b[31m╔═\x1b[0m\x1b[1m T \x1b[0m\x1b[31m═══╗\x1b[0m\n\
+\x1b[31m║\x1b[0m  Hi   \x1b[31m║\x1b[0m\n\
+\x1b[31m╚═══════╝\x1b[0m\n"
+    );
+}
+
+#[test]
+fn renders_progress_spinners_and_tables_byte_for_byte() {
+    let progress = run("import charm\n\
+charm.progress(5, 10, 'Load', 10, 'cyan', 1.25)\n\
+charm.progress_done()\n\
+charm.spinner(13, 'Wait', '#abc')\n\
+charm.progress_done()\n\
+print(repr(charm.spinner_frame(13)))");
+    assert!(progress.status.success(), "{}", text(&progress.stderr));
+    assert_eq!(
+        text(&progress.stdout),
+        "\rLoad \x1b[36m█████░░░░░\x1b[0m 50%  1.3s\x1b[K\n\
+\r\x1b[38;2;170;187;204m⠸\x1b[0m Wait\x1b[K\n\
+'⠸'\n"
+    );
+
+    let table = run("import charm; charm.table([['Name','界'],['Ana','7']], True)");
+    assert!(table.status.success(), "{}", text(&table.stderr));
+    assert_eq!(
+        text(&table.stdout),
+        "┌──────┬────┐\n\
+│ \x1b[1mName\x1b[0m │ \x1b[1m界\x1b[0m │\n\
+├──────┼────┤\n\
+│ Ana  │ 7  │\n\
+└──────┴────┘\n"
+    );
+}
+
+#[test]
+fn preserves_empty_results_and_argument_errors() {
+    let empty = run("import charm; print(charm.table([])); print(charm.table([[]]))");
+    assert!(empty.status.success(), "{}", text(&empty.stderr));
+    assert_eq!(text(&empty.stdout), "None\nNone\n");
+
+    for (source, expected) in [
+        (
+            "import charm; charm.visible_len('x' * 4096)",
+            "ValueError: text too long",
+        ),
+        (
+            "import charm; charm.style(1)",
+            "TypeError: text must be a string",
+        ),
+        (
+            "import charm; charm.progress('1', 2)",
+            "TypeError: current must be int",
+        ),
+        (
+            "import charm; charm.spinner_frame('1')",
+            "TypeError: index must be int",
+        ),
+        (
+            "import charm; charm.table(1)",
+            "TypeError: rows must be a list",
+        ),
+        (
+            "import charm; charm.table([1])",
+            "TypeError: each row must be a list",
+        ),
+    ] {
+        let output = run(source);
+        assert_eq!(output.status.code(), Some(1));
+        assert!(text(&output.stdout).contains(expected));
+        assert!(text(&output.stderr).contains("Python execution failed"));
+    }
+}
+
+fn run(source: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pocketpy-ucharm-rs"))
+        .args(["-c", source])
+        .output()
+        .expect("run Rust PocketPy runtime")
+}
+
+fn text(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}

--- a/scripts/generate-rust-bindings.sh
+++ b/scripts/generate-rust-bindings.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 RUST_LOG=error bindgen "$project_root/pocketpy/vendor/pocketpy.h" \
-  --allowlist-function 'py_(initialize|finalize|exec|printexc|sys_setargv|newmodule|getmodule|bind|bindfunc|retval|newint|newbool|newnone|newstrn|newtuple|tuple_len|tuple_getitem|tuple_setitem|newlist|list_len|list_getitem|list_append|newdict|dict_getitem|dict_setitem|dict_apply|name|getdict|pushtmp|pop|tpobject|isidentical|istype|toint|tostrn|tobool|exception)' \
+  --allowlist-function 'py_(initialize|finalize|exec|printexc|sys_setargv|newmodule|getmodule|bind|bindfunc|retval|newint|newbool|newnone|newstrn|newtuple|tuple_len|tuple_getitem|tuple_setitem|newlist|list_len|list_getitem|list_append|newdict|dict_getitem|dict_setitem|dict_apply|name|getdict|setdict|pushtmp|pop|tpobject|isidentical|istype|toint|tofloat|tostrn|tobool|exception)' \
   --allowlist-type 'py_(CompileMode|PredefinedType|TValue|Name)' \
   --use-core \
   --no-layout-tests \


### PR DESCRIPTION
## Summary

- port the complete native `charm` presentation module and reusable TUI core to the Rust-hosted PocketPy runtime
- preserve Zig-compatible constants, signatures, keyword-binding quirks, ANSI bytes, Unicode-width behavior, borders, tables, progress bars, spinners, and error behavior
- extend table-driven registration with rooted integer constants and numeric conversion
- add golden Python integration tests and a four-target CI smoke check
- update the migration plan to mark the representative Phase 4 module gate complete

Tracks #13.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- Zig/Rust differential matrix for every public `charm` function plus arity/type errors
- Zig compatibility baseline: 1,668 / 1,668
- `cargo audit`
- PocketPy vendor patch verification
- ARM64 and x86_64 macOS release builds and `charm` smoke tests

## Measurements

- macOS ARM64 runtime: 651,184 bytes; median startup 2.664 ms over 30 measured runs
- macOS x86_64 runtime: 690,656 bytes
- both remain below the 2 MB runtime gate
