### PR TITLE
test: harden PocketPy FFI boundary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,30 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
 
+  ffi-sanitizers:
+    name: PocketPy FFI sanitizers
+    runs-on: ubuntu-24.04
+    env:
+      CFLAGS: -fsanitize=address,undefined -fno-omit-frame-pointer
+      RUSTFLAGS: -C link-arg=-fsanitize=address -C link-arg=-fsanitize=undefined -C link-arg=-lasan -C link-arg=-lubsan
+      ASAN_OPTIONS: detect_leaks=1:halt_on_error=1:strict_string_checks=1
+      LSAN_OPTIONS: exitcode=23
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build instrumented PocketPy tests
+        run: cargo test -p ucharm-runtime --lib --test ffi_stress --no-run
+      - name: Stress PocketPy callbacks and lifecycle
+        shell: bash
+        run: |
+          export LD_PRELOAD="$(gcc -print-file-name=libasan.so)"
+          test_count=0
+          while IFS= read -r test_binary; do
+            "$test_binary" --test-threads=1
+            test_count=$((test_count + 1))
+          done < <(find target/debug/deps -maxdepth 1 -type f -executable \( -name 'ucharm_runtime-*' -o -name 'ffi_stress-*' \) | sort)
+          test "$test_count" -eq 2
+
   build:
     name: Rust build (${{ matrix.target }})
     strategy:
@@ -48,7 +72,7 @@ jobs:
         shell: bash
         run: >-
           target/${{ matrix.target }}/release/pocketpy-ucharm-rs
-          -c 'import _ucharm_rust, ansi, args, charm, input, term; assert _ucharm_rust.answer() == 42; assert ansi.fg("red") == "\x1b[31m"; assert args.count() == 1; assert charm.BORDER_ROUNDED == 0; assert charm.visible_len(charm.style("界", fg="red")) == 2; assert input.select("", []) is None; assert input.multiselect("", []) == []; assert len(term.size()) == 2; assert term.raw_mode(False) is None'
+          -c 'import ansi, args, charm, input, term; assert ansi.fg("red") == "\x1b[31m"; assert args.count() == 1; assert charm.BORDER_ROUNDED == 0; assert charm.visible_len(charm.style("界", fg="red")) == 2; assert input.select("", []) is None; assert input.multiselect("", []) == []; assert len(term.size()) == 2; assert term.raw_mode(False) is None'
       - name: Smoke-test Rust CLI
         shell: bash
         run: target/${{ matrix.target }}/release/ucharm-rs --version | grep -q "μcharm"

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -183,9 +183,12 @@ status, stdout, and stderr.
   confirmation, editing, cancellation, and password screen bytes match Zig.
   The reusable Rust TUI core preserves the Zig runtime's byte-oriented width,
   color, border, progress, spinner, and table behavior, including its historical
-  keyword-binding quirks. The representative Phase 4 module gate is now met;
-  leak/sanitizer and callback-lifetime hardening are next. The `_ucharm_rust`
-  probe remains temporarily as an FFI smoke test while that hardening finishes.
+  keyword-binding quirks. Phase 4 is functionally complete: allocation and
+  exception stress crosses every production Rust callback module, explicit
+  tests enforce the one-owner VM lifecycle, and Linux CI instruments PocketPy C
+  with AddressSanitizer, UndefinedBehaviorSanitizer, and leak detection. The
+  original `_ucharm_rust` proof module has been retired; the first pure-module
+  Phase 5 wave is next.
 - The initial stripped macOS ARM64 Rust spine is about 600 KB before μcharm's
   native modules and external C dependencies are added. This is an early
   feasibility signal, not a final size comparison.

--- a/crates/ucharm-runtime/src/lib.rs
+++ b/crates/ucharm-runtime/src/lib.rs
@@ -92,7 +92,6 @@ impl Vm {
                 let vm = Self {
                     _not_send_or_sync: PhantomData,
                 };
-                vm.register_probe_module();
                 modules::register_all();
                 Ok(vm)
             }
@@ -143,22 +142,6 @@ impl Vm {
         // reports a pending Python exception.
         unsafe { ffi::py_printexc() };
     }
-
-    fn register_probe_module(&self) {
-        // SAFETY: `self` proves the VM is active. The C string literals have
-        // static storage, and the callback uses PocketPy's required ABI.
-        unsafe {
-            let module = ffi::py_newmodule(c"_ucharm_rust".as_ptr());
-            ffi::py_bindfunc(module, c"answer".as_ptr(), Some(probe_answer));
-        }
-    }
-}
-
-unsafe extern "C" fn probe_answer(_argc: i32, _argv: ffi::py_StackRef) -> bool {
-    // SAFETY: PocketPy invokes this callback with an active VM and owns the
-    // return register. `py_newint` writes a complete Python integer into it.
-    unsafe { ffi::py_newint(ffi::py_retval(), 42) };
-    true
 }
 
 impl Drop for Vm {
@@ -175,16 +158,19 @@ impl Drop for Vm {
 mod tests {
     use std::ffi::CString;
 
-    use super::Vm;
+    use super::{InitializeError, Vm};
 
     #[test]
-    fn executes_python_through_pocketpy() {
+    fn enforces_the_process_lifecycle_and_executes_python() {
         let vm = Vm::initialize().expect("initialize PocketPy");
+        assert!(matches!(
+            Vm::initialize(),
+            Err(InitializeError::AlreadyActive)
+        ));
         let arguments = [CString::new("-c").expect("valid C string")];
         vm.set_argv(&arguments);
         vm.execute_str(
-            "import _ucharm_rust, ansi, sys\n\
-assert _ucharm_rust.answer() == 42\n\
+            "import ansi, sys\n\
 assert sys.argv == ['-c']\n\
 assert ansi.fg('red') == '\\x1b[31m'\n\
 assert ansi.bg('#f50') == '\\x1b[48;2;255;85;0m'\n\
@@ -193,5 +179,11 @@ assert ansi.strikethrough() == '\\x1b[9m'",
             "<rust-test>",
         )
         .expect("execute Python");
+
+        drop(vm);
+        assert!(matches!(
+            Vm::initialize(),
+            Err(InitializeError::AlreadyFinalized)
+        ));
     }
 }

--- a/crates/ucharm-runtime/tests/ffi_stress.rs
+++ b/crates/ucharm-runtime/tests/ffi_stress.rs
@@ -1,0 +1,92 @@
+use std::process::{Command, Output};
+
+#[test]
+fn keeps_callback_values_rooted_across_allocation_and_exception_stress() {
+    let output = run(
+        concat!(
+            "import ansi, args, charm, input, term\n",
+            "spec = {\n",
+            "    '--name': str,\n",
+            "    '--count': (int, 0),\n",
+            "    '--verbose': bool,\n",
+            "    '-n': '--name',\n",
+            "}\n",
+            "retained = []\n",
+            "for i in range(4000):\n",
+            "    parsed = args.parse(spec)\n",
+            "    assert parsed['name'] == 'alice'\n",
+            "    assert parsed['count'] == 42\n",
+            "    assert parsed['verbose'] is True\n",
+            "    assert parsed['_'] == ['tail']\n",
+            "    retained.append(parsed)\n",
+            "    if len(retained) == 32:\n",
+            "        for value in retained:\n",
+            "            assert value['name'] == 'alice'\n",
+            "            assert value['count'] == 42\n",
+            "        retained = []\n",
+            "    styled = charm.style('界', fg='#abc', bold=True)\n",
+            "    assert styled == '\\x1b[1;38;2;170;187;204m界\\x1b[0m'\n",
+            "    assert charm.visible_len(styled) == 2\n",
+            "    expected = '\\x1b[38;2;' + str(i % 256) + ';' + str((i + 1) % 256) + ';' + str((i + 2) % 256) + 'm'\n",
+            "    assert ansi.rgb(i, i + 1, i + 2) == expected\n",
+            "    assert input.select('', []) is None\n",
+            "    assert input.multiselect('', []) == []\n",
+            "    assert len(term.size()) == 2\n",
+            "    caught = False\n",
+            "    try:\n",
+            "        args.get('bad index')\n",
+            "    except TypeError:\n",
+            "        caught = True\n",
+            "    assert caught\n",
+            "assert len(retained) == 0",
+        ),
+        &["--name=alice", "--count", "42", "--verbose", "tail"],
+    );
+
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(text(&output.stdout), "");
+    assert_eq!(text(&output.stderr), "");
+}
+
+#[test]
+fn repeatedly_initializes_executes_and_finalizes_the_runtime_process() {
+    for cycle in 0..24 {
+        let output = run(
+            concat!(
+                "import args, charm\n",
+                "for i in range(100):\n",
+                "    assert args.parse({'--value': (int, 7)}) == {'_': [], 'value': 9}\n",
+                "    assert charm.spinner_frame(i) == charm.spinner_frame(i + 10)",
+            ),
+            &["--value=9"],
+        );
+        assert!(
+            output.status.success(),
+            "runtime cycle {cycle} failed:\n{}",
+            diagnostic(&output)
+        );
+        assert_eq!(text(&output.stdout), "");
+        assert_eq!(text(&output.stderr), "");
+    }
+}
+
+fn run(source: &str, arguments: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pocketpy-ucharm-rs"))
+        .args(["-c", source])
+        .args(arguments)
+        .output()
+        .expect("run Rust PocketPy runtime")
+}
+
+fn text(output: &impl AsRef<[u8]>) -> String {
+    String::from_utf8_lossy(output.as_ref()).into_owned()
+}
+
+fn diagnostic(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        text(&output.stdout),
+        text(&output.stderr)
+    )
+}


### PR DESCRIPTION
## Summary

- add allocation, exception, rooting, and process-lifecycle stress coverage across every production Rust callback module
- enforce PocketPy's one-owner, initialize-once/finalize-once lifecycle in the Rust unit suite
- instrument vendored PocketPy C with AddressSanitizer, UndefinedBehaviorSanitizer, and leak detection in a dedicated Linux CI job
- retire the temporary `_ucharm_rust` proof module now that production modules own the FFI smoke path
- mark Phase 4 functionally complete and identify the first Phase 5 pure-module wave as next

Tracks #13.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- exact sanitizer job passed in a clean Rust 1.97 Linux container
- `cargo audit`
- PocketPy vendor patch verification
- Zig release compatibility baseline: 1,668 / 1,668
- ARM64 and x86_64 macOS release builds and production-module smoke tests

## Measurements

- macOS ARM64 runtime: 651,168 bytes; median startup 2.303 ms over 30 measured runs
- macOS x86_64 runtime: 690,656 bytes
- both remain below the 2 MB runtime gate
