### PR TITLE
Port crypto, compression, and archive wave to Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,11 @@ jobs:
         run: >-
           target/${{ matrix.target }}/release/pocketpy-ucharm-rs
           -c 'import array, secrets, struct; values = array.array("I", [0x12345678, 0x90ABCDEF]); encoded = values.tobytes(); assert struct.unpack("<2I", encoded) == (0x12345678, 0x90ABCDEF); buffer = bytearray(8); struct.pack_into(">I", buffer, 2, 0xAABBCCDD); assert struct.unpack_from(">I", buffer, 2) == (0xAABBCCDD,); assert len(secrets.token_bytes(8)) == 8; assert 0 <= secrets.randbelow(17) < 17'
+      - name: Smoke-test Rust crypto-compression wave
+        shell: bash
+        run: >-
+          target/${{ matrix.target }}/release/pocketpy-ucharm-rs
+          -c 'import gzip, hashlib, hmac, io, tarfile, zipfile; data = b"ucharm" * 256; assert hashlib.sha256(data).hexdigest() == "1dbf127f11e331f8adb707abb311daf83009edad8ae7964e88d41b86ebd2faca"; assert len(hmac.new(b"key", data, "sha256").digest()) == 32; assert gzip.decompress(gzip.compress(data)) == data; buffer = io.BytesIO(data); buffer.seek(6); assert buffer.read(6) == b"ucharm"; assert hasattr(zipfile, "ZipFile"); assert hasattr(tarfile, "TarFile")'
       - name: Smoke-test Rust CLI
         shell: bash
         run: target/${{ matrix.target }}/release/ucharm-rs --version | grep -q "μcharm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +49,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +82,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "hybrid-array"
@@ -94,6 +119,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +155,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "typenum"
@@ -147,6 +199,10 @@ dependencies = [
 name = "ucharm-runtime"
 version = "0.5.0"
 dependencies = [
+ "flate2",
  "libc",
+ "md-5",
+ "sha1",
+ "sha2",
  "ucharm-pocketpy-sys",
 ]

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,9 +5,9 @@ This is the single source of truth for priorities and next steps.
 ## Snapshot
 
 - Goal: build beautiful CLI apps with Python syntax, shipped as tiny, fast binaries.
-- Runtime: PocketPy with a Zig host today; the native host, modules, CLI, and loader are migrating to stable Rust.
+- Runtime: PocketPy; the Rust host, loader, CLI, and 30 fully compatible stdlib targets are implemented while the remaining native modules migrate from Zig.
 - Language decision: Rust is the target implementation language. See `RUST_MIGRATION.md` for gates and sequencing.
-- Compatibility status: `tests/compat_report_pocketpy.md` shows 51/52 targeted modules at 100% parity (1 has no baseline on the host CPython version). Refresh with `python3 tests/compat_runner.py --report`.
+- Compatibility status: the Rust migration runtime passes 1,185/1,668 checks (71.0%), with 30/52 targeted modules at 100% parity. Refresh with `python3 tests/compat_runner.py --runtime target/debug/pocketpy-ucharm-rs --report`.
 - PocketPy vendor patches are tracked under `pocketpy/patches/` and verified via `python3 scripts/verify-pocketpy-patches.py --check-upstream`.
 
 ## Current State (from the repo)
@@ -47,16 +47,14 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
 
 ## What to Focus on Next
 
-1. Record the reproducible Zig baseline and add golden/differential fixtures.
-2. Prove Rust-hosted PocketPy and C dependency builds on all four release targets.
-3. Port the universal format/loader, then the CLI around existing runtime assets.
-4. Port the runtime and native modules without allowing compatibility to fall below the current baseline.
-5. Cut CI and releases to Rust, remove Zig, then continue the product roadmap below.
+1. Finish the remaining Rust runtime module waves without regressing the 1,668-check baseline.
+2. Run a four-target release candidate and cut CI, packaging, and releases fully to Rust.
+3. Remove Zig after the Rust release is proven, then continue the product roadmap below.
 
 ## Product Roadmap After the Rust Cutover
 
 ### Phase A: Close feature gap (Vision)
-- Maintain the Vision “nice-to-have” surface (`toml`/`tomllib`, `http.client`, `secrets`, `hmac`, `dataclasses`, `xml.etree`, `sqlite3`, and archive helpers).
+- Maintain the Vision “nice-to-have” surface; remaining gaps include `toml`/`tomllib`, `http.client`, `xml.etree`, and `sqlite3`.
 - Keep the suite honest by expanding tests when behavior changes.
 
 ### Phase B: Developer experience
@@ -73,7 +71,6 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
 
 - Tree-shaking or module selection for smaller binaries.
 - `ucharm dev` (watch mode / hot reload).
-- Networking and formats: `http.client`, `toml`, `yaml`, `gzip`, `zipfile`, `tarfile`.
-- Security: `secrets`, `hmac`.
+- Networking and formats: `http.client`, `toml`, `yaml`.
 - Concurrency: `threading`, `queue` (PocketPy threading support TBD).
 - Database: `sqlite3` (likely large; consider an optional build flag / separate release flavor).

--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ ucharm/
 
 Current compatibility summary (from `tests/compat_report_pocketpy.md`):
 
-- 1,646/1,646 tests passing (CLI-focused targeted modules)
-- 52 targeted modules (50/52 at 100% on host CPython; 2 have no baseline on older CPython versions)
+- Rust migration runtime: 1,185/1,668 tests passing (71.0%)
+- 52 targeted modules, with 30 at 100% parity on the Rust host
 - ~3ms startup, ~1-2MB universal binaries (sqlite enabled)
 
 ## Showcase

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -192,7 +192,9 @@ status, stdout, and stderr.
   `textwrap`, `heapq`, `typing`, `itertools`, `errno`, `copy`, `functools`, and
   `operator` are now joined by the first data/model wave: `collections`, `csv`,
   `dataclasses`, `datetime`, `json`, `random`, and `uuid`; and the binary-
-  container wave: `array`, `struct`, and `secrets`.
+  container wave: `array`, `struct`, and `secrets`; plus the crypto,
+  compression, and archive wave: `hashlib`, `hmac`, `gzip`, `io`, `zipfile`,
+  and `tarfile`.
   The shared boundary copies PocketPy bytes into owned Rust buffers before
   allocation, roots
   exact-size byte and float results, supports equality and ordered comparison,
@@ -231,15 +233,20 @@ status, stdout, and stderr.
   review cycle. Array values remain VM/GC-owned, while a narrow native format
   core handles checked endian conversion, float packing, mutable `bytearray`
   writes, and stable-register tuple construction. Secure tokens and unbiased
-  `randbelow` reuse the OS entropy boundary. The full Rust result is now
-  1,079/1,668 (64.7%), up from the original 456/1,668.
+  `randbelow` reuse the OS entropy boundary. The crypto/compression wave adds
+  RustCrypto-backed MD5/SHA-1/SHA-2 and HMAC, bounded pure-Rust gzip/deflate,
+  full in-memory byte/text buffers, stored/deflated ZIP reads, and USTAR reads.
+  It completes 106 additional compatibility checks, with CPython differential,
+  allocation-stress, invalid-input, and cross-target smoke coverage. The full
+  Rust result is now 1,185/1,668 (71.0%), up from the original 456/1,668.
   Related low-risk modules now move as validated waves; standalone PRs are
   reserved for boundaries whose ownership or binary-format risk warrants them.
-- The current stripped macOS runtime is 734,688 bytes on ARM64 and 769,296
+- The current stripped macOS runtime is 817,648 bytes on ARM64 and 900,768
   bytes on x86_64, versus 2,313,264 bytes for the legacy Zig ARM64 runtime.
-  On the 400-run warm-start sample, native Rust measured 3.574 ms median and
-  3.738 ms p95, versus Zig's 3.378 ms median and 3.601 ms p95; x86_64 Rust
-  under Rosetta measured 9.484 ms median and 10.943 ms p95.
+  On the latest 400-run warm-start sample, native Rust measured 4.740 ms median
+  and 5.521 ms p95; x86_64 Rust under Rosetta measured 12.435 ms median and
+  17.032 ms p95. The native ARM64 host remains below the 10 ms gate; native
+  Intel CI remains the authoritative x86_64 execution environment.
 
 ### Phase 0 — Freeze and baseline
 

--- a/crates/ucharm-runtime/Cargo.toml
+++ b/crates/ucharm-runtime/Cargo.toml
@@ -7,7 +7,11 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 libc = "0.2"
+md-5 = { version = "0.11.0", default-features = false }
+sha1 = { version = "0.11.0", default-features = false }
+sha2 = { version = "0.11", default-features = false }
 ucharm-pocketpy-sys = { path = "../pocketpy-sys" }
 
 [lints]

--- a/crates/ucharm-runtime/src/modules/bytes_methods.rs
+++ b/crates/ucharm-runtime/src/modules/bytes_methods.rs
@@ -1,0 +1,39 @@
+use std::ffi::c_int;
+
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{Arguments, Value, bind_type_signature, return_bytes, type_error, value_error};
+
+const MAX_BYTES_SIZE: usize = 64 * 1024 * 1024;
+
+pub(super) fn register() {
+    let bytes_type = ffi::py_PredefinedType_tp_bytes as ffi::py_Type;
+    bind_type_signature(bytes_type, c"__mul__(self, count)", multiply);
+    bind_type_signature(bytes_type, c"__rmul__(self, count)", multiply);
+}
+
+unsafe extern "C" fn multiply(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(2, 2) {
+        return false;
+    }
+    let Some(bytes) = arguments.get(0).and_then(Value::bytes) else {
+        return type_error(c"expected bytes");
+    };
+    let Some(count) = arguments.get(1).and_then(Value::integer) else {
+        return type_error(c"can't multiply sequence by non-int");
+    };
+    if count <= 0 || bytes.is_empty() {
+        return return_bytes(&[]);
+    }
+    let Ok(count) = usize::try_from(count) else {
+        return value_error(c"repeated bytes are too large");
+    };
+    let Some(length) = bytes.len().checked_mul(count) else {
+        return value_error(c"repeated bytes are too large");
+    };
+    if length > MAX_BYTES_SIZE {
+        return value_error(c"repeated bytes are too large");
+    }
+    return_bytes(&bytes.repeat(count))
+}

--- a/crates/ucharm-runtime/src/modules/csv.rs
+++ b/crates/ucharm-runtime/src/modules/csv.rs
@@ -1,24 +1,6 @@
 use crate::native::{NativeModule, NativeModuleKind, Value, execute_module};
 
 const COMPATIBILITY_SOURCE: &str = r#"
-import io
-
-
-class _RustStringIO:
-    def __init__(self, initial_value=""):
-        self._value = initial_value
-
-    def write(self, value):
-        self._value += value
-        return len(value)
-
-    def getvalue(self):
-        return self._value
-
-
-io.StringIO = _RustStringIO
-
-
 QUOTE_MINIMAL = 0
 QUOTE_ALL = 1
 QUOTE_NONNUMERIC = 2

--- a/crates/ucharm-runtime/src/modules/gzip.rs
+++ b/crates/ucharm-runtime/src/modules/gzip.rs
@@ -1,0 +1,95 @@
+use std::ffi::c_int;
+use std::io::{Read, Write};
+
+use flate2::Compression;
+use flate2::read::{DeflateDecoder, GzDecoder};
+use flate2::write::GzEncoder;
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{
+    Arguments, NativeFunction, NativeModule, NativeModuleKind, Value, return_bytes, runtime_error,
+    type_error, value_error,
+};
+
+const MAX_DATA_SIZE: usize = 64 * 1024 * 1024;
+
+const FUNCTIONS: &[NativeFunction] = &[
+    NativeFunction {
+        name: c"compress",
+        callback: compress,
+    },
+    NativeFunction {
+        name: c"decompress",
+        callback: decompress,
+    },
+    NativeFunction {
+        name: c"_inflate_raw",
+        callback: inflate_raw,
+    },
+];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"gzip",
+    kind: NativeModuleKind::Create,
+    functions: FUNCTIONS,
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: None,
+};
+
+unsafe extern "C" fn compress(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Some(input) = bytes_argument(argc, argv) else {
+        return false;
+    };
+    if input.len() > MAX_DATA_SIZE {
+        return value_error(c"data too large");
+    }
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    if encoder.write_all(&input).is_err() {
+        return runtime_error(c"gzip compression failed");
+    }
+    match encoder.finish() {
+        Ok(output) => return_bytes(&output),
+        Err(_) => runtime_error(c"gzip compression failed"),
+    }
+}
+
+unsafe extern "C" fn decompress(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Some(input) = bytes_argument(argc, argv) else {
+        return false;
+    };
+    decode_limited(GzDecoder::new(input.as_slice()))
+}
+
+unsafe extern "C" fn inflate_raw(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Some(input) = bytes_argument(argc, argv) else {
+        return false;
+    };
+    decode_limited(DeflateDecoder::new(input.as_slice()))
+}
+
+fn decode_limited(mut decoder: impl Read) -> bool {
+    let mut output = Vec::new();
+    match decoder
+        .by_ref()
+        .take(u64::try_from(MAX_DATA_SIZE + 1).expect("fixed limit fits u64"))
+        .read_to_end(&mut output)
+    {
+        Ok(_) if output.len() <= MAX_DATA_SIZE => return_bytes(&output),
+        Ok(_) => value_error(c"decompressed data too large"),
+        Err(_) => value_error(c"invalid compressed data"),
+    }
+}
+
+fn bytes_argument(argc: c_int, argv: ffi::py_StackRef) -> Option<Vec<u8>> {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return None;
+    }
+    let Some(input) = arguments.get(0).and_then(Value::bytes) else {
+        type_error(c"a bytes-like object is required");
+        return None;
+    };
+    Some(input)
+}

--- a/crates/ucharm-runtime/src/modules/hash_core.rs
+++ b/crates/ucharm-runtime/src/modules/hash_core.rs
@@ -1,0 +1,68 @@
+use md5::Md5;
+use sha1::Sha1;
+use sha2::{Digest, Sha256, Sha512};
+
+#[derive(Clone, Copy)]
+pub(super) enum Algorithm {
+    Md5,
+    Sha1,
+    Sha256,
+    Sha512,
+}
+
+impl Algorithm {
+    pub(super) fn parse(name: &str) -> Option<Self> {
+        match name.to_ascii_lowercase().replace('-', "").as_str() {
+            "md5" => Some(Self::Md5),
+            "sha1" => Some(Self::Sha1),
+            "sha256" => Some(Self::Sha256),
+            "sha512" => Some(Self::Sha512),
+            _ => None,
+        }
+    }
+
+    pub(super) const fn digest_size(self) -> usize {
+        match self {
+            Self::Md5 => 16,
+            Self::Sha1 => 20,
+            Self::Sha256 => 32,
+            Self::Sha512 => 64,
+        }
+    }
+
+    pub(super) const fn block_size(self) -> usize {
+        match self {
+            Self::Sha512 => 128,
+            Self::Md5 | Self::Sha1 | Self::Sha256 => 64,
+        }
+    }
+}
+
+pub(super) fn digest(algorithm: Algorithm, input: &[u8]) -> Vec<u8> {
+    match algorithm {
+        Algorithm::Md5 => Md5::digest(input).to_vec(),
+        Algorithm::Sha1 => Sha1::digest(input).to_vec(),
+        Algorithm::Sha256 => Sha256::digest(input).to_vec(),
+        Algorithm::Sha512 => Sha512::digest(input).to_vec(),
+    }
+}
+
+pub(super) fn hmac(algorithm: Algorithm, key: &[u8], message: &[u8]) -> Vec<u8> {
+    let block_size = algorithm.block_size();
+    let mut normalized_key = if key.len() > block_size {
+        digest(algorithm, key)
+    } else {
+        key.to_vec()
+    };
+    normalized_key.resize(block_size, 0);
+
+    let mut inner = Vec::with_capacity(block_size + message.len());
+    let mut outer = Vec::with_capacity(block_size + algorithm.digest_size());
+    for byte in normalized_key {
+        inner.push(byte ^ 0x36);
+        outer.push(byte ^ 0x5c);
+    }
+    inner.extend_from_slice(message);
+    outer.extend_from_slice(&digest(algorithm, &inner));
+    digest(algorithm, &outer)
+}

--- a/crates/ucharm-runtime/src/modules/hashlib.rs
+++ b/crates/ucharm-runtime/src/modules/hashlib.rs
@@ -1,0 +1,114 @@
+use std::ffi::c_int;
+
+use ucharm_pocketpy_sys as ffi;
+
+use super::hash_core::{self, Algorithm};
+use crate::native::{
+    Arguments, NativeFunction, NativeModule, NativeModuleKind, Value, execute_module, return_bytes,
+    type_error, value_error,
+};
+
+const COMPATIBILITY_SOURCE: &str = r#"
+import binascii
+
+
+class _Hash:
+    def __init__(self, algorithm, data=None):
+        if data is None:
+            data = b""
+        self._algorithm = algorithm
+        self._data = data
+        if algorithm == "md5":
+            self.digest_size = 16
+            self.block_size = 64
+        elif algorithm == "sha1":
+            self.digest_size = 20
+            self.block_size = 64
+        elif algorithm == "sha256":
+            self.digest_size = 32
+            self.block_size = 64
+        else:
+            self.digest_size = 64
+            self.block_size = 128
+
+    def update(self, data):
+        if not isinstance(data, bytes):
+            raise TypeError("a bytes-like object is required")
+        self._data += data
+
+    def digest(self):
+        return _digest(self._algorithm, self._data)
+
+    def hexdigest(self):
+        return binascii.hexlify(self.digest()).decode()
+
+    def copy(self):
+        return _Hash(self._algorithm, self._data)
+
+
+def md5(data=None):
+    return _Hash("md5", data)
+
+
+def sha1(data=None):
+    return _Hash("sha1", data)
+
+
+def sha256(data=None):
+    return _Hash("sha256", data)
+
+
+def sha512(data=None):
+    return _Hash("sha512", data)
+
+
+def new(name, data=None):
+    normalized = name.lower().replace("-", "")
+    if normalized not in ("md5", "sha1", "sha256", "sha512"):
+        raise ValueError("unsupported hash type")
+    return _Hash(normalized, data)
+
+
+algorithms_guaranteed = {"md5", "sha1", "sha256", "sha512"}
+algorithms_available = algorithms_guaranteed
+"#;
+
+const FUNCTIONS: &[NativeFunction] = &[NativeFunction {
+    name: c"_digest",
+    callback: digest,
+}];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"hashlib",
+    kind: NativeModuleKind::Create,
+    functions: FUNCTIONS,
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, COMPATIBILITY_SOURCE) {
+        // SAFETY: initialization failed with a live PocketPy exception.
+        unsafe { ucharm_pocketpy_sys::py_printexc() };
+        panic!("embedded hashlib compatibility layer failed");
+    }
+}
+
+unsafe extern "C" fn digest(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(2, 2) {
+        return false;
+    }
+    let Some(name) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"hash name must be a string");
+    };
+    let Some(input) = arguments.get(1).and_then(Value::bytes) else {
+        return type_error(c"a bytes-like object is required");
+    };
+    let Some(algorithm) = Algorithm::parse(&name) else {
+        return value_error(c"unsupported hash type");
+    };
+    return_bytes(&hash_core::digest(algorithm, &input))
+}

--- a/crates/ucharm-runtime/src/modules/hmac.rs
+++ b/crates/ucharm-runtime/src/modules/hmac.rs
@@ -1,0 +1,121 @@
+use std::ffi::c_int;
+
+use ucharm_pocketpy_sys as ffi;
+
+use super::hash_core::{self, Algorithm};
+use crate::native::{
+    Arguments, NativeFunction, NativeModule, NativeModuleKind, RootFrame, Value, execute_module,
+    return_bytes, return_value, type_error, value_error,
+};
+
+const COMPATIBILITY_SOURCE: &str = r#"
+import binascii
+
+
+class HMAC:
+    def __init__(self, key, msg=None, digestmod="sha256"):
+        if msg is None:
+            msg = b""
+        self._key = key
+        self._message = msg
+        if isinstance(digestmod, str):
+            self._algorithm = digestmod.lower().replace("-", "")
+        else:
+            self._algorithm = digestmod.__name__
+        if self._algorithm not in ("md5", "sha1", "sha256", "sha512"):
+            raise ValueError("unsupported hash type")
+        self.digest_size = len(self.digest())
+        self.block_size = 128 if self._algorithm == "sha512" else 64
+
+    def update(self, msg):
+        if not isinstance(msg, bytes):
+            raise TypeError("a bytes-like object is required")
+        self._message += msg
+
+    def digest(self):
+        return _hmac_digest(self._algorithm, self._key, self._message)
+
+    def hexdigest(self):
+        return binascii.hexlify(self.digest()).decode()
+
+    def copy(self):
+        return HMAC(self._key, self._message, self._algorithm)
+
+
+def new(key, msg=None, digestmod="sha256"):
+    return HMAC(key, msg, digestmod)
+"#;
+
+const FUNCTIONS: &[NativeFunction] = &[
+    NativeFunction {
+        name: c"_hmac_digest",
+        callback: hmac_digest,
+    },
+    NativeFunction {
+        name: c"compare_digest",
+        callback: compare_digest,
+    },
+];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"hmac",
+    kind: NativeModuleKind::Create,
+    functions: FUNCTIONS,
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, COMPATIBILITY_SOURCE) {
+        // SAFETY: initialization failed with a live PocketPy exception.
+        unsafe { ucharm_pocketpy_sys::py_printexc() };
+        panic!("embedded hmac compatibility layer failed");
+    }
+}
+
+unsafe extern "C" fn hmac_digest(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(3, 3) {
+        return false;
+    }
+    let Some(name) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"hash name must be a string");
+    };
+    let Some(key) = arguments.get(1).and_then(Value::bytes) else {
+        return type_error(c"key must be bytes");
+    };
+    let Some(message) = arguments.get(2).and_then(Value::bytes) else {
+        return type_error(c"msg must be bytes");
+    };
+    let Some(algorithm) = Algorithm::parse(&name) else {
+        return value_error(c"unsupported hash type");
+    };
+    return_bytes(&hash_core::hmac(algorithm, &key, &message))
+}
+
+unsafe extern "C" fn compare_digest(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(2, 2) {
+        return false;
+    }
+    let left = arguments.get(0).expect("arity checked");
+    let right = arguments.get(1).expect("arity checked");
+    let (left, right) = if let (Some(left), Some(right)) = (left.bytes(), right.bytes()) {
+        (left, right)
+    } else if let (Some(left), Some(right)) = (left.string(), right.string()) {
+        (left.into_bytes(), right.into_bytes())
+    } else {
+        return type_error(c"unsupported operand types for compare_digest");
+    };
+    let mut difference = left.len() ^ right.len();
+    for index in 0..left.len().max(right.len()) {
+        let left_byte = left.get(index).copied().unwrap_or(0);
+        let right_byte = right.get(index).copied().unwrap_or(0);
+        difference |= usize::from(left_byte ^ right_byte);
+    }
+    let mut roots = RootFrame::new();
+    let result = roots.boolean(difference == 0);
+    return_value(result)
+}

--- a/crates/ucharm-runtime/src/modules/io.rs
+++ b/crates/ucharm-runtime/src/modules/io.rs
@@ -1,0 +1,184 @@
+use crate::native::{NativeModule, NativeModuleKind, Value, execute_module};
+
+const COMPATIBILITY_SOURCE: &str = r#"
+class _Buffer:
+    def _initialize(self, initial_value, binary):
+        if binary:
+            if not isinstance(initial_value, bytes):
+                raise TypeError("a bytes-like object is required")
+            self._empty = b""
+            self._zero = b"\x00"
+            self._newline = 10
+        else:
+            if not isinstance(initial_value, str):
+                raise TypeError("initial_value must be str")
+            self._empty = ""
+            self._zero = "\x00"
+            self._newline = "\n"
+        self._binary = binary
+        self._value = initial_value
+        self._position = 0
+        self.closed = False
+
+    def _check_open(self):
+        if self.closed:
+            raise ValueError("I/O operation on closed file")
+
+    def getvalue(self):
+        self._check_open()
+        return self._value
+
+    def tell(self):
+        self._check_open()
+        return self._position
+
+    def seek(self, offset, whence=0):
+        self._check_open()
+        if whence == 0:
+            position = offset
+        elif whence == 1:
+            position = self._position + offset
+        elif whence == 2:
+            position = len(self._value) + offset
+        else:
+            raise ValueError("invalid whence")
+        if position < 0:
+            raise ValueError("negative seek position")
+        self._position = position
+        return position
+
+    def read(self, size=-1):
+        self._check_open()
+        if size is None or size < 0:
+            end = len(self._value)
+        else:
+            end = self._position + size
+            if end > len(self._value):
+                end = len(self._value)
+        if self._position >= len(self._value):
+            return self._empty
+        output = self._value[self._position:end]
+        self._position = end
+        return output
+
+    def write(self, value):
+        self._check_open()
+        if self._binary:
+            if not isinstance(value, bytes):
+                raise TypeError("a bytes-like object is required")
+        elif not isinstance(value, str):
+            raise TypeError("string argument expected")
+        while self._position > len(self._value):
+            self._value += self._zero
+        end = self._position + len(value)
+        suffix = self._empty
+        if end < len(self._value):
+            suffix = self._value[end:]
+        self._value = self._value[:self._position] + value + suffix
+        self._position = end
+        return len(value)
+
+    def readline(self, size=-1):
+        self._check_open()
+        if self._position >= len(self._value) or size == 0:
+            return self._empty
+        start = self._position
+        end = start
+        while end < len(self._value) and (size is None or size < 0 or end - start < size):
+            current = self._value[end]
+            end += 1
+            if current == self._newline:
+                break
+        self._position = end
+        return self._value[start:end]
+
+    def readlines(self, hint=-1):
+        self._check_open()
+        output = []
+        total = 0
+        while True:
+            line = self.readline()
+            if line == self._empty:
+                break
+            output.append(line)
+            total += len(line)
+            if hint is not None and hint > 0 and total >= hint:
+                break
+        return output
+
+    def writelines(self, lines):
+        self._check_open()
+        for line in lines:
+            self.write(line)
+
+    def truncate(self, size=None):
+        self._check_open()
+        if size is None:
+            size = self._position
+        if size < 0:
+            raise ValueError("negative size value")
+        if size < len(self._value):
+            self._value = self._value[:size]
+        return size
+
+    def close(self):
+        self.closed = True
+
+    def flush(self):
+        self._check_open()
+
+    def readable(self):
+        return not self.closed
+
+    def writable(self):
+        return not self.closed
+
+    def seekable(self):
+        return not self.closed
+
+    def __enter__(self):
+        self._check_open()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        line = self.readline()
+        if line == self._empty:
+            raise StopIteration
+        return line
+
+
+class BytesIO(_Buffer):
+    def __init__(self, initial_bytes=None):
+        if initial_bytes is None:
+            initial_bytes = b""
+        self._initialize(initial_bytes, True)
+
+
+class StringIO(_Buffer):
+    def __init__(self, initial_value="", newline=None):
+        self._initialize(initial_value, False)
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"io",
+    kind: NativeModuleKind::ImportAndExtend,
+    functions: &[],
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, COMPATIBILITY_SOURCE) {
+        // SAFETY: initialization failed with a live PocketPy exception.
+        unsafe { ucharm_pocketpy_sys::py_printexc() };
+        panic!("embedded io compatibility layer failed");
+    }
+}

--- a/crates/ucharm-runtime/src/modules/mod.rs
+++ b/crates/ucharm-runtime/src/modules/mod.rs
@@ -5,6 +5,7 @@ mod array;
 mod base64;
 mod binascii;
 mod bytearray;
+mod bytes_methods;
 mod charm;
 mod charm_core;
 mod collections;
@@ -17,8 +18,13 @@ mod errno;
 mod fnmatch;
 mod fnmatch_core;
 mod functools;
+mod gzip;
+mod hash_core;
+mod hashlib;
 mod heapq;
+mod hmac;
 mod input;
+mod io;
 mod itertools;
 mod json;
 mod operator;
@@ -28,12 +34,14 @@ mod statistics;
 mod statistics_core;
 mod string_methods;
 mod struct_module;
+mod tarfile;
 mod term;
 mod term_core;
 mod textwrap;
 mod textwrap_core;
 mod typing;
 mod uuid;
+mod zipfile;
 
 use crate::native::{NativeModule, register_modules};
 
@@ -48,13 +56,17 @@ const MODULES: &[NativeModule] = &[
     copy::MODULE,
     typing::MODULE,
     collections::MODULE,
+    io::MODULE,
     csv::MODULE,
     dataclasses::MODULE,
     datetime::MODULE,
     errno::MODULE,
     fnmatch::MODULE,
     functools::MODULE,
+    gzip::MODULE,
+    hashlib::MODULE,
     heapq::MODULE,
+    hmac::MODULE,
     input::MODULE,
     itertools::MODULE,
     json::MODULE,
@@ -62,13 +74,16 @@ const MODULES: &[NativeModule] = &[
     random::MODULE,
     secrets::MODULE,
     statistics::MODULE,
+    tarfile::MODULE,
     term::MODULE,
     textwrap::MODULE,
     uuid::MODULE,
+    zipfile::MODULE,
 ];
 
 pub(crate) fn register_all() {
     string_methods::register();
+    bytes_methods::register();
     bytearray::register();
     register_modules(MODULES);
 }

--- a/crates/ucharm-runtime/src/modules/tarfile.rs
+++ b/crates/ucharm-runtime/src/modules/tarfile.rs
@@ -1,0 +1,125 @@
+use std::ffi::c_int;
+
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{
+    Arguments, NativeFunction, NativeModule, NativeModuleKind, Value, execute_module, return_bytes,
+    runtime_error, type_error, value_error,
+};
+
+const MAX_ARCHIVE_SIZE: usize = 64 * 1024 * 1024;
+
+const COMPATIBILITY_SOURCE: &str = r#"
+import io
+
+
+ReadError = ValueError
+
+
+def _text_field(data):
+    end = 0
+    while end < len(data) and data[end] != 0:
+        end += 1
+    return data[:end].decode()
+
+
+def _octal_field(data):
+    text = _text_field(data).strip()
+    if text == "":
+        return 0
+    return int(text, 8)
+
+
+def is_tarfile(name):
+    try:
+        data = _read_file(name)
+        return len(data) >= 512 and data[257:262] == b"ustar"
+    except Exception:
+        return False
+
+
+class TarFile:
+    def __init__(self, name, mode="r"):
+        if mode != "r":
+            raise ValueError("only read mode is supported")
+        self._data = _read_file(name)
+        self._entries = []
+        self.closed = False
+        offset = 0
+        while offset + 512 <= len(self._data):
+            header = self._data[offset:offset + 512]
+            if header[0] == 0:
+                break
+            name = _text_field(header[:100])
+            size = _octal_field(header[124:136])
+            typeflag = header[156]
+            data_offset = offset + 512
+            if typeflag == 0 or typeflag == 48:
+                self._entries.append((name, data_offset, size))
+            offset = data_offset + ((size + 511) // 512) * 512
+        if len(self._entries) == 0 and not is_tarfile(name):
+            raise ReadError("not a tar archive")
+
+    def getnames(self):
+        names = []
+        for entry in self._entries:
+            names.append(entry[0])
+        return names
+
+    def extractfile(self, member):
+        for entry in self._entries:
+            if entry[0] == member:
+                return io.BytesIO(self._data[entry[1]:entry[1] + entry[2]])
+        return None
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+def open(name, mode="r"):
+    return TarFile(name, mode)
+"#;
+
+const FUNCTIONS: &[NativeFunction] = &[NativeFunction {
+    name: c"_read_file",
+    callback: read_file,
+}];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"tarfile",
+    kind: NativeModuleKind::Create,
+    functions: FUNCTIONS,
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, COMPATIBILITY_SOURCE) {
+        // SAFETY: initialization failed with a live PocketPy exception.
+        unsafe { ucharm_pocketpy_sys::py_printexc() };
+        panic!("embedded tarfile compatibility layer failed");
+    }
+}
+
+unsafe extern "C" fn read_file(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return false;
+    }
+    let Some(path) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"filename must be a string");
+    };
+    match std::fs::read(path) {
+        Ok(data) if data.len() <= MAX_ARCHIVE_SIZE => return_bytes(&data),
+        Ok(_) => value_error(c"archive is too large"),
+        Err(_) => runtime_error(c"unable to read archive"),
+    }
+}

--- a/crates/ucharm-runtime/src/modules/zipfile.rs
+++ b/crates/ucharm-runtime/src/modules/zipfile.rs
@@ -1,0 +1,132 @@
+use std::ffi::c_int;
+
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{
+    Arguments, NativeFunction, NativeModule, NativeModuleKind, Value, execute_module, return_bytes,
+    runtime_error, type_error, value_error,
+};
+
+const MAX_ARCHIVE_SIZE: usize = 64 * 1024 * 1024;
+
+const COMPATIBILITY_SOURCE: &str = r#"
+from gzip import _inflate_raw
+
+
+ZIP_STORED = 0
+ZIP_DEFLATED = 8
+BadZipFile = ValueError
+
+
+def _u16(data, offset):
+    return data[offset] | (data[offset + 1] << 8)
+
+
+def _u32(data, offset):
+    return _u16(data, offset) | (_u16(data, offset + 2) << 16)
+
+
+def is_zipfile(filename):
+    try:
+        data = _read_file(filename)
+        return len(data) >= 4 and data[:4] == b"PK\x03\x04"
+    except Exception:
+        return False
+
+
+class ZipFile:
+    def __init__(self, file, mode="r", compression=0):
+        if mode != "r":
+            raise ValueError("only read mode is supported")
+        self._data = _read_file(file)
+        self._entries = []
+        self._closed = False
+        offset = 0
+        while offset + 46 <= len(self._data):
+            if self._data[offset:offset + 4] == b"PK\x01\x02":
+                method = _u16(self._data, offset + 10)
+                compressed_size = _u32(self._data, offset + 20)
+                size = _u32(self._data, offset + 24)
+                name_length = _u16(self._data, offset + 28)
+                extra_length = _u16(self._data, offset + 30)
+                comment_length = _u16(self._data, offset + 32)
+                local_offset = _u32(self._data, offset + 42)
+                name_start = offset + 46
+                name = self._data[name_start:name_start + name_length].decode()
+                self._entries.append((name, method, compressed_size, size, local_offset))
+                offset = name_start + name_length + extra_length + comment_length
+            else:
+                offset += 1
+        if len(self._entries) == 0:
+            raise BadZipFile("File is not a zip file")
+
+    def namelist(self):
+        names = []
+        for entry in self._entries:
+            names.append(entry[0])
+        return names
+
+    def read(self, name):
+        for entry in self._entries:
+            if entry[0] == name:
+                local_offset = entry[4]
+                if self._data[local_offset:local_offset + 4] != b"PK\x03\x04":
+                    raise BadZipFile("Bad local file header")
+                name_length = _u16(self._data, local_offset + 26)
+                extra_length = _u16(self._data, local_offset + 28)
+                start = local_offset + 30 + name_length + extra_length
+                compressed = self._data[start:start + entry[2]]
+                if entry[1] == ZIP_STORED:
+                    return compressed
+                if entry[1] == ZIP_DEFLATED:
+                    return _inflate_raw(compressed)
+                raise NotImplementedError("compression method is not supported")
+        raise KeyError(name)
+
+    def close(self):
+        self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+"#;
+
+const FUNCTIONS: &[NativeFunction] = &[NativeFunction {
+    name: c"_read_file",
+    callback: read_file,
+}];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"zipfile",
+    kind: NativeModuleKind::Create,
+    functions: FUNCTIONS,
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, COMPATIBILITY_SOURCE) {
+        // SAFETY: initialization failed with a live PocketPy exception.
+        unsafe { ucharm_pocketpy_sys::py_printexc() };
+        panic!("embedded zipfile compatibility layer failed");
+    }
+}
+
+unsafe extern "C" fn read_file(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return false;
+    }
+    let Some(path) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"filename must be a string");
+    };
+    match std::fs::read(path) {
+        Ok(data) if data.len() <= MAX_ARCHIVE_SIZE => return_bytes(&data),
+        Ok(_) => value_error(c"archive is too large"),
+        Err(_) => runtime_error(c"unable to read archive"),
+    }
+}

--- a/crates/ucharm-runtime/tests/crypto_compression_wave.rs
+++ b/crates/ucharm-runtime/tests/crypto_compression_wave.rs
@@ -1,0 +1,150 @@
+use std::process::{Command, Output};
+
+#[test]
+fn passes_all_crypto_compression_and_archive_fixtures() {
+    for (module, source, summary) in [
+        (
+            "hashlib",
+            include_str!("../../../tests/cpython/test_hashlib.py"),
+            "Results: 29 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "hmac",
+            include_str!("../../../tests/cpython/test_hmac.py"),
+            "Results: 4 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "gzip",
+            include_str!("../../../tests/cpython/test_gzip.py"),
+            "Results: 6 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "zipfile",
+            include_str!("../../../tests/cpython/test_zipfile.py"),
+            "Results: 7 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "tarfile",
+            include_str!("../../../tests/cpython/test_tarfile.py"),
+            "Results: 7 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "io",
+            include_str!("../../../tests/cpython/test_io.py"),
+            "Results: 53 passed, 0 failed, 0 skipped",
+        ),
+    ] {
+        let output = run_runtime(source);
+        assert!(
+            output.status.success(),
+            "{module} fixture failed:\n{}",
+            diagnostic(&output)
+        );
+        assert!(
+            text(&output.stdout).contains(summary),
+            "{module} summary missing:\n{}",
+            diagnostic(&output)
+        );
+        assert_eq!(text(&output.stderr), "", "{module}");
+    }
+}
+
+#[test]
+fn matches_cpython_for_deterministic_crypto_compression_and_buffer_operations() {
+    let source = concat!(
+        "import gzip, hashlib, hmac, io\n",
+        "data = b'crypto-compression-wave' * 64\n",
+        "print(hashlib.md5(data).hexdigest())\n",
+        "print(hashlib.sha1(data).hexdigest())\n",
+        "print(hashlib.sha256(data).hexdigest())\n",
+        "print(hashlib.sha512(data).hexdigest())\n",
+        "print(hmac.new(b'key', data, 'sha256').hexdigest())\n",
+        "compressed = gzip.compress(data)\n",
+        "print(len(compressed) > 0)\n",
+        "print(gzip.decompress(compressed) == data)\n",
+        "buffer = io.BytesIO(b'abc')\n",
+        "buffer.seek(5); buffer.write(b'z')\n",
+        "print(len(buffer.getvalue()))\n",
+        "text = io.StringIO('alpha\\nbeta')\n",
+        "print(text.readline() == 'alpha\\n')\n",
+    );
+    let rust = run_runtime(source);
+    assert!(rust.status.success(), "{}", diagnostic(&rust));
+
+    let cpython = Command::new("python3")
+        .args(["-c", source])
+        .output()
+        .expect("run CPython differential oracle");
+    assert!(cpython.status.success(), "{}", diagnostic(&cpython));
+    assert_eq!(rust.stdout, cpython.stdout);
+    assert_eq!(text(&rust.stderr), "");
+}
+
+#[test]
+fn preserves_crypto_buffer_state_limits_and_error_paths_under_stress() {
+    let output = run_runtime(concat!(
+        "import gzip, hashlib, hmac, io\n",
+        "retained = []\n",
+        "for i in range(50):\n",
+        "    data = (str(i) + ':' + ('x' * 2048)).encode()\n",
+        "    digest = hashlib.sha256(data)\n",
+        "    first = digest.hexdigest()\n",
+        "    digest.update(b'!')\n",
+        "    assert first != digest.hexdigest()\n",
+        "    assert len(hmac.new(b'key', data, 'sha512').digest()) == 64\n",
+        "    packed = gzip.compress(data)\n",
+        "    assert gzip.decompress(packed) == data\n",
+        "    buffer = io.BytesIO(data)\n",
+        "    buffer.seek(10); buffer.write(b'abc')\n",
+        "    buffer.seek(0); assert len(buffer.read()) == len(data)\n",
+        "    retained.append((first, packed))\n",
+        "    if len(retained) == 32:\n",
+        "        for value in retained:\n",
+        "            assert len(value[0]) == 64 and len(value[1]) > 0\n",
+        "        retained = []\n",
+        "try:\n",
+        "    gzip.decompress(b'not-gzip')\n",
+        "    raise AssertionError('expected invalid gzip error')\n",
+        "except ValueError:\n",
+        "    pass\n",
+        "try:\n",
+        "    hashlib.new('not-a-hash')\n",
+        "    raise AssertionError('expected unsupported hash error')\n",
+        "except ValueError:\n",
+        "    pass\n",
+        "try:\n",
+        "    io.BytesIO('not-bytes')\n",
+        "    raise AssertionError('expected buffer type error')\n",
+        "except TypeError:\n",
+        "    pass\n",
+        "closed = io.StringIO('x')\n",
+        "closed.close()\n",
+        "try:\n",
+        "    closed.read()\n",
+        "    raise AssertionError('expected closed buffer error')\n",
+        "except ValueError:\n",
+        "    pass\n",
+    ));
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(text(&output.stderr), "");
+}
+
+fn run_runtime(source: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pocketpy-ucharm-rs"))
+        .args(["-c", source])
+        .output()
+        .expect("run Rust PocketPy runtime")
+}
+
+fn text(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn diagnostic(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        text(&output.stdout),
+        text(&output.stderr)
+    )
+}

--- a/tests/compat_report_pocketpy.md
+++ b/tests/compat_report_pocketpy.md
@@ -1,14 +1,14 @@
 # μcharm Compatibility Report
 
-Generated: 2026-08-04 10:01:48
+Generated: 2026-08-04 18:40:11
 
 ## Summary
 
 ### Targeted Modules
 
-- **Tests passing**: 1,668/1,668 (100.0%)
-- **Modules at 100%**: 51/52
-- **Modules partial**: 0/52
+- **Tests passing**: 1,185/1,668 (71.0%)
+- **Modules at 100%**: 30/52
+- **Modules partial**: 6/52
 - **No baseline (host CPython)**: 1/52
 
 ### CPython Stdlib Coverage
@@ -20,14 +20,11 @@ Generated: 2026-08-04 10:01:48
 
 | Module | Category | CPython | μcharm | Parity | Notes |
 |--------|----------|---------|--------|--------|-------|
-| argparse | stdlib | 26/26 | 26/26 | 100% | ✅ Full |
 | array | stdlib | 69/69 | 69/69 | 100% | ✅ Full |
 | base64 | stdlib | 18/18 | 18/18 | 100% | ✅ Full |
 | binascii | stdlib | 55/55 | 55/55 | 100% | ✅ Full |
 | bisect | stdlib | 58/58 | 58/58 | 100% | ✅ Full |
 | collections | stdlib | 49/49 | 49/49 | 100% | ✅ Full |
-| configparser | stdlib | 26/26 | 26/26 | 100% | ✅ Full |
-| contextlib | stdlib | 10/10 | 10/10 | 100% | ✅ Full |
 | copy | stdlib | 33/33 | 33/33 | 100% | ✅ Full |
 | csv | stdlib | 24/24 | 24/24 | 100% | ✅ Full |
 | dataclasses | stdlib | 8/8 | 8/8 | 100% | ✅ Full |
@@ -36,46 +33,115 @@ Generated: 2026-08-04 10:01:48
 | errno | stdlib | 38/38 | 38/38 | 100% | ✅ Full |
 | fnmatch | stdlib | 55/55 | 55/55 | 100% | ✅ Full |
 | functools | stdlib | 40/40 | 40/40 | 100% | ✅ Full |
-| glob | stdlib | 3/3 | 3/3 | 100% | ✅ Full |
 | gzip | stdlib | 6/6 | 6/6 | 100% | ✅ Full |
 | hashlib | stdlib | 29/29 | 29/29 | 100% | ✅ Full |
 | heapq | stdlib | 42/42 | 42/42 | 100% | ✅ Full |
 | hmac | stdlib | 4/4 | 4/4 | 100% | ✅ Full |
-| http.client | stdlib | 8/8 | 8/8 | 100% | ✅ Full |
 | io | stdlib | 53/53 | 53/53 | 100% | ✅ Full |
 | itertools | stdlib | 33/33 | 33/33 | 100% | ✅ Full |
 | json | stdlib | 70/70 | 70/70 | 100% | ✅ Full |
-| logging | stdlib | 39/39 | 39/39 | 100% | ✅ Full |
-| math | stdlib | 82/82 | 82/82 | 100% | ✅ Full |
 | operator | stdlib | 114/115 | 115/115 | 100% | ✅ Full |
-| os | stdlib | 45/45 | 45/45 | 100% | ✅ Full |
-| pathlib | stdlib | 40/40 | 40/40 | 100% | ✅ Full |
 | random | stdlib | 46/46 | 46/46 | 100% | ✅ Full |
-| re | stdlib | 79/79 | 79/79 | 100% | ✅ Full |
 | secrets | stdlib | 8/8 | 8/8 | 100% | ✅ Full |
-| shutil | stdlib | 6/6 | 6/6 | 100% | ✅ Full |
-| signal | stdlib | 15/15 | 15/15 | 100% | ✅ Full |
-| sqlite3 | stdlib | 2/2 | 2/2 | 100% | ✅ Full |
 | statistics | stdlib | 28/28 | 28/28 | 100% | ✅ Full |
 | struct | stdlib | 68/68 | 68/68 | 100% | ✅ Full |
-| subprocess | stdlib | 19/19 | 19/19 | 100% | ✅ Full |
-| sys | stdlib | 58/58 | 58/58 | 100% | ✅ Full |
 | tarfile | stdlib | 7/7 | 7/7 | 100% | ✅ Full |
-| tempfile | stdlib | 9/9 | 9/9 | 100% | ✅ Full |
 | textwrap | stdlib | 24/24 | 24/24 | 100% | ✅ Full |
-| time | stdlib | 42/42 | 42/42 | 100% | ✅ Full |
 | toml | stdlib | - | - | - | ✅ Full |
-| tomllib | stdlib | 0/1 | 1/1 | 100% | ✅ Full |
 | typing | stdlib | 43/43 | 43/43 | 100% | ✅ Full |
-| unittest | stdlib | 40/40 | 40/40 | 100% | ✅ Full |
-| urllib_parse | stdlib | 24/24 | 24/24 | 100% | ✅ Full |
 | uuid | stdlib | 18/18 | 18/18 | 100% | ✅ Full |
-| xml.etree.ElementTree | stdlib | 12/12 | 12/12 | 100% | ✅ Full |
 | zipfile | stdlib | 7/7 | 7/7 | 100% | ✅ Full |
+| math | stdlib | 82/82 | 73/82 | 89% | 9 skipped |
+| time | stdlib | 42/42 | 22/42 | 52% | 6 skipped |
+| os | stdlib | 45/45 | 3/45 | 7% |  |
+| sys | stdlib | 58/58 | 3/58 | 5% | 1 failing |
+| urllib_parse | stdlib | 24/24 | 1/24 | 4% | 1 skipped |
+| configparser | stdlib | 26/26 | 1/26 | 4% | 1 skipped |
+| argparse | stdlib | 26/26 | 0/26 | 0% | 1 skipped |
+| contextlib | stdlib | 10/10 | 0/10 | 0% | 1 failing |
+| glob | stdlib | 3/3 | 0/3 | 0% | 1 failing |
+| http.client | stdlib | 8/8 | 0/8 | 0% |  |
+| logging | stdlib | 39/39 | 0/39 | 0% | 1 failing |
+| pathlib | stdlib | 40/40 | 0/40 | 0% | 1 skipped |
+| re | stdlib | 79/79 | 0/79 | 0% | 1 failing |
+| shutil | stdlib | 6/6 | 0/6 | 0% | 1 failing |
+| signal | stdlib | 15/15 | 0/15 | 0% | 1 failing |
+| sqlite3 | stdlib | 2/2 | 0/2 | 0% |  |
+| subprocess | stdlib | 19/19 | 0/19 | 0% | 1 failing |
+| tempfile | stdlib | 9/9 | 0/9 | 0% | 1 failing |
+| tomllib | stdlib | 0/1 | 0/1 | 0% |  |
+| unittest | stdlib | 40/40 | 0/40 | 0% | 1 skipped |
+| xml.etree.ElementTree | stdlib | 12/12 | 0/12 | 0% |  |
+
+## Failed Tests
+
+### argparse
+
+- `error: Python execution failed
+`
+
+### contextlib
+
+- `error: Python execution failed
+`
+
+### re
+
+- `error: Python execution failed
+`
+
+### sys
+
+- `FAIL: version_info exists`
+
+### glob
+
+- `error: Python execution failed
+`
+
+### logging
+
+- `error: Python execution failed
+`
+
+### pathlib
+
+- `error: Python execution failed
+`
+
+### shutil
+
+- `error: Python execution failed
+`
+
+### signal
+
+- `error: Python execution failed
+`
+
+### subprocess
+
+- `error: Python execution failed
+`
+
+### tempfile
+
+- `error: Python execution failed
+`
+
+### unittest
+
+- `error: Python execution failed
+`
+
 
 ## Skipped Tests
 
 These tests require features not available in pocketpy-ucharm:
+
+### argparse
+
+- 1 tests skipped
 
 ### bisect
 
@@ -85,15 +151,39 @@ These tests require features not available in pocketpy-ucharm:
 
 - 4 tests skipped
 
-### contextlib
+### configparser
 
-- 4 tests skipped
+- 1 tests skipped
 
 ### enum
 
 - 8 tests skipped
 
 ### json
+
+- 1 tests skipped
+
+### math
+
+- 9 tests skipped
+
+### time
+
+- 6 tests skipped
+
+### urllib_parse
+
+- 1 tests skipped
+
+### pathlib
+
+- 1 tests skipped
+
+### toml
+
+- 1 tests skipped
+
+### unittest
 
 - 1 tests skipped
 


### PR DESCRIPTION
## What changed

- port `hashlib`, `hmac`, and `gzip` to the Rust-hosted PocketPy runtime
- add full in-memory `io.BytesIO` and `io.StringIO` compatibility
- add read support for stored/deflated ZIP archives and USTAR archives
- add bounded `bytes * int` support required by archive and buffer fixtures
- expand the four-target Rust release smoke and refresh the compatibility report and migration roadmap

## Why

This is the next Phase 5 module wave tracked by #13. The modules share hash, compression, byte-buffer, and archive boundaries, so moving them together avoids a chain of small prerequisite-only PRs.

Rust compatibility rises from 1,079/1,668 (64.7%) to 1,185/1,668 (71.0%), with six additional modules reaching complete fixture parity.

## Implementation notes

- RustCrypto provides MD5, SHA-1, SHA-256, SHA-512, and manual standards-compatible HMAC composition.
- `flate2` uses its pure-Rust backend for bounded gzip and raw-deflate decoding.
- PocketPy owns buffer and archive object state through embedded compatibility classes; native callbacks copy only bounded bytes and perform crypto/compression or file reads.
- gzip decompression, archive reads, and byte repetition are capped at 64 MiB.
- CSV now consumes the shared full `io.StringIO` implementation instead of installing a private minimal replacement.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- full compatibility report: 1,185/1,668 (71.0%), 30 full / 6 partial
- CPython differential checks plus crypto/compression allocation and error stress
- all six fixtures pass on optimized ARM64 and x86_64 macOS releases
- release sizes: 817,648 bytes ARM64; 900,768 bytes x86_64
- 400-run native ARM64 startup: 4.740 ms median / 5.521 ms p95

Tracks #13.
