### PR TITLE
Port the Rust filesystem wave

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,6 +83,11 @@ jobs:
         run: >-
           target/${{ matrix.target }}/release/pocketpy-ucharm-rs
           -c 'import gzip, hashlib, hmac, io, tarfile, zipfile; data = b"ucharm" * 256; assert hashlib.sha256(data).hexdigest() == "1dbf127f11e331f8adb707abb311daf83009edad8ae7964e88d41b86ebd2faca"; assert len(hmac.new(b"key", data, "sha256").digest()) == 32; assert gzip.decompress(gzip.compress(data)) == data; buffer = io.BytesIO(data); buffer.seek(6); assert buffer.read(6) == b"ucharm"; assert hasattr(zipfile, "ZipFile"); assert hasattr(tarfile, "TarFile")'
+      - name: Smoke-test Rust filesystem wave
+        shell: bash
+        run: >-
+          target/${{ matrix.target }}/release/pocketpy-ucharm-rs
+          -c 'import glob, os, shutil, tempfile; from pathlib import Path; root = tempfile.mkdtemp("/tmp/ucharm-fs-smoke-"); nested = os.path.join(root, "nested"); os.makedirs(nested, exist_ok=True); source = os.path.join(nested, "source.txt"); file = open(source, "w"); file.write("ucharm"); file.close(); assert Path(source).is_file(); assert glob.glob(os.path.join(root, "**", "*.txt"), None, None, True) == [source]; copied = os.path.join(root, "copied.txt"); shutil.copy(source, copied); assert Path(copied).is_file(); shutil.rmtree(root); assert not os.path.exists(root)'
       - name: Smoke-test Rust CLI
         shell: bash
         run: target/${{ matrix.target }}/release/ucharm-rs --version | grep -q "μcharm"

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,9 +5,9 @@ This is the single source of truth for priorities and next steps.
 ## Snapshot
 
 - Goal: build beautiful CLI apps with Python syntax, shipped as tiny, fast binaries.
-- Runtime: PocketPy; the Rust host, loader, CLI, and 30 fully compatible stdlib targets are implemented while the remaining native modules migrate from Zig.
+- Runtime: PocketPy; the Rust host, loader, CLI, and 35 fully compatible stdlib targets are implemented while the remaining native modules migrate from Zig.
 - Language decision: Rust is the target implementation language. See `RUST_MIGRATION.md` for gates and sequencing.
-- Compatibility status: the Rust migration runtime passes 1,185/1,668 checks (71.0%), with 30/52 targeted modules at 100% parity. Refresh with `python3 tests/compat_runner.py --runtime target/debug/pocketpy-ucharm-rs --report`.
+- Compatibility status: the Rust migration runtime passes 1,285/1,668 checks (77.0%), with 35/52 targeted modules at 100% parity. Refresh with `python3 tests/compat_runner.py --runtime target/debug/pocketpy-ucharm-rs --report`.
 - PocketPy vendor patches are tracked under `pocketpy/patches/` and verified via `python3 scripts/verify-pocketpy-patches.py --check-upstream`.
 
 ## Current State (from the repo)
@@ -53,15 +53,35 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
 
 ## Product Roadmap After the Rust Cutover
 
-### Phase A: Close feature gap (Vision)
+### Phase A: Migration documentation and public retrospective
+- Revisit the README, website, and all user/contributor documentation once the
+  Rust release is proven. Remove stale Zig architecture, commands, examples,
+  screenshots, performance claims, and download instructions.
+- Add a migration section to the website and publish a polished retrospective,
+  either as a three-part series or one long-form article with clear sections:
+  1. **Why** — repository-specific maintenance, ownership, ecosystem, and
+     governance reasons, while acknowledging Zig's strengths.
+  2. **How** — the incremental architecture, compatibility gates, FFI safety,
+     differential tests, four-target CI, and release cutover.
+  3. **Outcome** — what improved, what regressed, what remains, and what we
+     would do differently.
+- Finish with reproducible, well-presented statistics and charts: compatibility
+  over time, migrated modules and lines, binary sizes, startup distributions,
+  CI/target coverage, defects found during migration, dependencies, and the
+  final Zig-versus-Rust artifact comparison. Link every headline number to its
+  committed benchmark or compatibility source.
+- Preserve the migration issue, plan, final Zig tag, and major PRs as an
+  engineering case study rather than erasing the project history.
+
+### Phase B: Close feature gap (Vision)
 - Maintain the Vision “nice-to-have” surface; remaining gaps include `toml`/`tomllib`, `http.client`, `xml.etree`, and `sqlite3`.
 - Keep the suite honest by expanding tests when behavior changes.
 
-### Phase B: Developer experience
+### Phase C: Developer experience
 - Decide the canonical stub source (Rust registration metadata or `stubs/`) and wire `scripts/generate_stubs.py` or a CLI command to regenerate them.
 - Update templates and docs to reference the canonical stubs and correct import paths.
 
-### Phase C: Packaging + release hygiene
+### Phase D: Packaging + release hygiene
 - Add a CI step that runs `python3 tests/compat_runner.py --report` and uploads the report as an artifact.
 - Add a CI step that runs `python3 scripts/verify-pocketpy-patches.py --check-upstream`.
 - Validate cross-target build support (`ucharm build --targets` and a sample `--target` build).

--- a/README.md
+++ b/README.md
@@ -270,9 +270,10 @@ ucharm/
 
 Current compatibility summary (from `tests/compat_report_pocketpy.md`):
 
-- Rust migration runtime: 1,185/1,668 tests passing (71.0%)
-- 52 targeted modules, with 30 at 100% parity on the Rust host
-- ~3ms startup, ~1-2MB universal binaries (sqlite enabled)
+- Rust migration runtime: 1,285/1,668 tests passing (77.0%)
+- 52 targeted modules, with 35 at 100% parity on the Rust host
+- 4.298ms median native ARM64 startup and an 851,888-byte stripped runtime in
+  the latest 400-run migration sample
 
 ## Showcase
 

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -238,14 +238,20 @@ status, stdout, and stderr.
   full in-memory byte/text buffers, stored/deflated ZIP reads, and USTAR reads.
   It completes 106 additional compatibility checks, with CPython differential,
   allocation-stress, invalid-input, and cross-target smoke coverage. The full
-  Rust result is now 1,185/1,668 (71.0%), up from the original 456/1,668.
+  filesystem wave adds `os`, `os.path`, `pathlib`, `glob`, `tempfile`, and
+  `shutil`, including real environment exposure, script `__file__`, recursive
+  path lifecycle and error stress, deterministic CPython path differentials,
+  and release smoke tests on both macOS architectures. Its five fixtures pass
+  109/109 raw checks; the conservative CPython-baselined report gains 100
+  checks. The full Rust result is now 1,285/1,668 (77.0%), up from the original
+  456/1,668, with 35 of 52 targeted modules at full parity.
   Related low-risk modules now move as validated waves; standalone PRs are
   reserved for boundaries whose ownership or binary-format risk warrants them.
-- The current stripped macOS runtime is 817,648 bytes on ARM64 and 900,768
+- The current stripped macOS runtime is 851,888 bytes on ARM64 and 934,784
   bytes on x86_64, versus 2,313,264 bytes for the legacy Zig ARM64 runtime.
-  On the latest 400-run warm-start sample, native Rust measured 4.740 ms median
-  and 5.521 ms p95; x86_64 Rust under Rosetta measured 12.435 ms median and
-  17.032 ms p95. The native ARM64 host remains below the 10 ms gate; native
+  On the latest 400-run warm-start sample, native Rust measured 4.298 ms median
+  and 5.241 ms p95; x86_64 Rust under Rosetta measured 11.107 ms median and
+  12.113 ms p95. The native ARM64 host remains below the 10 ms gate; native
   Intel CI remains the authoritative x86_64 execution environment.
 
 ### Phase 0 — Freeze and baseline
@@ -356,14 +362,27 @@ artifacts meet the compatibility, startup, and size gates.
   after the Rust release is proven. Preserve the last Zig tag and migration
   notes for archaeology.
 - Update architecture documentation and contributor guidance.
+- After the Rust release is proven, complete a public documentation and
+  communication pass before treating the migration as old news:
+  - audit the README, website, docs, templates, examples, installation paths,
+    architecture diagrams, and benchmark claims for stale Zig-era content;
+  - add a website blog/migration section covering **why** μcharm moved, **how**
+    the incremental rewrite worked, and **what the outcome was**;
+  - publish reproducible final statistics and polished charts for compatibility
+    progress, migrated surface area, binary size, startup distributions,
+    four-target CI, dependencies, and migration-discovered defects;
+  - link the numbers back to committed reports and benchmarks, preserve the
+    final Zig tag and migration tracker, and report regressions and tradeoffs as
+    explicitly as improvements.
 - Resume roadmap work in this order:
-  1. canonical stub generation and CI drift checking;
-  2. compatibility report and PocketPy patch verification artifacts;
-  3. cross-target build reliability;
-  4. tree-shaking/module selection for size;
-  5. `ucharm dev` watch mode;
-  6. remaining networking, format, concurrency, and database work;
-  7. higher-level TUI features from `vision.md`.
+  1. README/website/docs refresh and the migration retrospective;
+  2. canonical stub generation and CI drift checking;
+  3. compatibility report and PocketPy patch verification artifacts;
+  4. cross-target build reliability;
+  5. tree-shaking/module selection for size;
+  6. `ucharm dev` watch mode;
+  7. remaining networking, format, concurrency, and database work;
+  8. higher-level TUI features from `vision.md`.
 
 ## Suggested PR Sequence
 

--- a/crates/ucharm-runtime/src/lib.rs
+++ b/crates/ucharm-runtime/src/lib.rs
@@ -137,6 +137,23 @@ impl Vm {
         unsafe { ffi::py_sys_setargv(pointers.len() as i32, pointers.as_mut_ptr()) };
     }
 
+    pub fn set_file(&self, filename: &str) -> Result<(), NulError> {
+        let filename = CString::new(filename)?;
+        let bytes = filename.as_bytes();
+        let length = i32::try_from(bytes.len()).expect("script path fits PocketPy string length");
+        // SAFETY: the VM is active, `__main__` is a process-global module, and
+        // register zero is a stable VM root used synchronously for assignment.
+        unsafe {
+            let main = ffi::py_getmodule(c"__main__".as_ptr());
+            assert!(!main.is_null(), "PocketPy main module is missing");
+            let value = ffi::py_getreg(0);
+            let destination = ffi::py_newstrn(value, length);
+            ptr::copy_nonoverlapping(bytes.as_ptr(), destination.cast::<u8>(), bytes.len());
+            ffi::py_setdict(main, ffi::py_name(c"__file__".as_ptr()), value);
+        }
+        Ok(())
+    }
+
     pub fn print_exception(&self) {
         // SAFETY: `self` proves the VM is active. Call this only after an API
         // reports a pending Python exception.

--- a/crates/ucharm-runtime/src/main.rs
+++ b/crates/ucharm-runtime/src/main.rs
@@ -19,7 +19,7 @@ fn run() -> Result<(), String> {
     let arguments: Vec<String> = env::args().collect();
     let vm = Vm::initialize().map_err(|error| error.to_string())?;
 
-    let (source, filename, python_arguments) = match arguments.as_slice() {
+    let (source, filename, python_arguments, script_file) = match arguments.as_slice() {
         [program] => {
             return Err(format!("usage: {program} [-c code | script.py] [args...]"));
         }
@@ -29,7 +29,7 @@ fn run() -> Result<(), String> {
                 .chain(rest.iter().map(String::as_str))
                 .map(str::to_owned)
                 .collect();
-            (code.clone(), "<string>".to_owned(), argv)
+            (code.clone(), "<string>".to_owned(), argv, None)
         }
         [_, flag] if flag == "-c" => return Err("-c requires an argument".to_owned()),
         [_, script, rest @ ..] => {
@@ -38,7 +38,7 @@ fn run() -> Result<(), String> {
             let argv = std::iter::once(script.clone())
                 .chain(rest.iter().cloned())
                 .collect();
-            (source, script.clone(), argv)
+            (source, script.clone(), argv, Some(script.clone()))
         }
         _ => unreachable!("the no-argument case is handled above"),
     };
@@ -49,6 +49,10 @@ fn run() -> Result<(), String> {
         .collect::<Result<_, _>>()
         .map_err(|_| "an argument contains a NUL byte".to_owned())?;
     vm.set_argv(&python_arguments);
+    if let Some(script_file) = script_file {
+        vm.set_file(&script_file)
+            .map_err(|_| "script path contains a NUL byte".to_owned())?;
+    }
 
     match vm.execute_str(&source, &filename) {
         Ok(()) => Ok(()),

--- a/crates/ucharm-runtime/src/modules/filesystem_core.rs
+++ b/crates/ucharm-runtime/src/modules/filesystem_core.rs
@@ -1,0 +1,24 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static UNIQUE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub(super) fn unique_path(prefix: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let counter = UNIQUE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    PathBuf::from(format!("{prefix}{}-{stamp}-{counter}", std::process::id()))
+}
+
+pub(super) fn temporary_directory() -> PathBuf {
+    std::env::var_os("TMPDIR")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+}
+
+pub(super) fn path_string(path: &Path) -> Option<String> {
+    path.to_str().map(ToOwned::to_owned)
+}

--- a/crates/ucharm-runtime/src/modules/glob.rs
+++ b/crates/ucharm-runtime/src/modules/glob.rs
@@ -1,0 +1,101 @@
+use std::ffi::c_int;
+use std::path::{Path, PathBuf};
+
+use ucharm_pocketpy_sys as ffi;
+
+use super::{filesystem_core, fnmatch_core};
+use crate::native::{
+    Arguments, NativeModule, NativeModuleKind, NativeSignature, Value, os_error,
+    return_string_list, type_error,
+};
+
+const SIGNATURES: &[NativeSignature] = &[NativeSignature {
+    signature: c"glob(pathname, root_dir=None, dir_fd=None, recursive=False)",
+    callback: glob,
+}];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"glob",
+    kind: NativeModuleKind::Create,
+    functions: &[],
+    signatures: SIGNATURES,
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: None,
+};
+
+unsafe extern "C" fn glob(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(pattern) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"pattern must be a string");
+    };
+    let recursive = arguments.get(3).and_then(Value::boolean).unwrap_or(false);
+    let mut results = Vec::new();
+
+    if recursive && let Some(marker) = pattern.find("**") {
+        let base = pattern[..marker].trim_end_matches('/');
+        let tail = pattern[marker + 2..].trim_start_matches('/');
+        let name_pattern = tail.rsplit('/').next().unwrap_or(tail);
+        let root = if base.is_empty() { "." } else { base };
+        if walk(Path::new(root), name_pattern, 0, &mut results).is_err() {
+            return os_error(c"failed to walk directory");
+        }
+        results.sort();
+        return return_string_list(&results);
+    }
+
+    let (directory, name_pattern) = match pattern.rsplit_once('/') {
+        Some(("", name)) => ("/", name),
+        Some((directory, name)) => (directory, name),
+        None => (".", pattern.as_str()),
+    };
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return return_string_list(&[]);
+    };
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(ToOwned::to_owned) else {
+            continue;
+        };
+        if !fnmatch_core::matches(name_pattern, &name) {
+            continue;
+        }
+        let path = if directory == "/" {
+            PathBuf::from(format!("/{name}"))
+        } else {
+            Path::new(directory).join(name)
+        };
+        if let Some(path) = filesystem_core::path_string(&path) {
+            results.push(path);
+        }
+    }
+    results.sort();
+    return_string_list(&results)
+}
+
+fn walk(
+    directory: &Path,
+    name_pattern: &str,
+    depth: usize,
+    results: &mut Vec<String>,
+) -> std::io::Result<()> {
+    if depth > 64 {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(directory)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            walk(&path, name_pattern, depth + 1, results)?;
+        } else if file_type.is_file()
+            && entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| fnmatch_core::matches(name_pattern, name))
+            && let Some(path) = filesystem_core::path_string(&path)
+        {
+            results.push(path);
+        }
+    }
+    Ok(())
+}

--- a/crates/ucharm-runtime/src/modules/mod.rs
+++ b/crates/ucharm-runtime/src/modules/mod.rs
@@ -15,9 +15,11 @@ mod dataclasses;
 mod datetime;
 mod encoding_core;
 mod errno;
+mod filesystem_core;
 mod fnmatch;
 mod fnmatch_core;
 mod functools;
+mod glob;
 mod gzip;
 mod hash_core;
 mod hashlib;
@@ -28,13 +30,18 @@ mod io;
 mod itertools;
 mod json;
 mod operator;
+mod os;
+mod os_path;
+mod pathlib;
 mod random;
 mod secrets;
+mod shutil;
 mod statistics;
 mod statistics_core;
 mod string_methods;
 mod struct_module;
 mod tarfile;
+mod tempfile;
 mod term;
 mod term_core;
 mod textwrap;
@@ -62,6 +69,10 @@ const MODULES: &[NativeModule] = &[
     datetime::MODULE,
     errno::MODULE,
     fnmatch::MODULE,
+    os::MODULE,
+    os_path::MODULE,
+    pathlib::MODULE,
+    glob::MODULE,
     functools::MODULE,
     gzip::MODULE,
     hashlib::MODULE,
@@ -74,7 +85,9 @@ const MODULES: &[NativeModule] = &[
     random::MODULE,
     secrets::MODULE,
     statistics::MODULE,
+    shutil::MODULE,
     tarfile::MODULE,
+    tempfile::MODULE,
     term::MODULE,
     textwrap::MODULE,
     uuid::MODULE,

--- a/crates/ucharm-runtime/src/modules/os.rs
+++ b/crates/ucharm-runtime/src/modules/os.rs
@@ -1,0 +1,204 @@
+use std::ffi::c_int;
+use std::os::unix::fs::MetadataExt;
+
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{
+    Arguments, NativeFunction, NativeModule, NativeModuleKind, NativeSignature, RootFrame, Value,
+    execute_module, os_error, return_string_list, return_value, type_error,
+};
+
+const COMPATIBILITY_SOURCE: &str = r#"
+sep = "/"
+name = "posix"
+linesep = "\n"
+
+
+def getenv(key, default=None):
+    if not isinstance(key, str):
+        raise TypeError("key must be a string")
+    if key in environ:
+        return environ[key]
+    return default
+"#;
+
+const FUNCTIONS: &[NativeFunction] = &[
+    NativeFunction {
+        name: c"remove",
+        callback: remove,
+    },
+    NativeFunction {
+        name: c"unlink",
+        callback: remove,
+    },
+    NativeFunction {
+        name: c"rmdir",
+        callback: rmdir,
+    },
+    NativeFunction {
+        name: c"stat",
+        callback: stat,
+    },
+];
+
+const SIGNATURES: &[NativeSignature] = &[
+    NativeSignature {
+        signature: c"listdir(path='.')",
+        callback: listdir,
+    },
+    NativeSignature {
+        signature: c"mkdir(path, mode=511)",
+        callback: mkdir,
+    },
+    NativeSignature {
+        signature: c"makedirs(name, mode=511, exist_ok=False)",
+        callback: makedirs,
+    },
+];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"os",
+    kind: NativeModuleKind::ImportAndExtend,
+    functions: FUNCTIONS,
+    signatures: SIGNATURES,
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, COMPATIBILITY_SOURCE) {
+        // SAFETY: initialization failed with a live PocketPy exception.
+        unsafe { ffi::py_printexc() };
+        panic!("embedded os compatibility layer failed");
+    }
+    let mut roots = RootFrame::new();
+    let environment = roots.dict();
+    for (key, value) in std::env::vars() {
+        let Some(key) = roots.string(&key) else {
+            continue;
+        };
+        let Some(value) = roots.string(&value) else {
+            continue;
+        };
+        if !environment.dict_set(key, value) {
+            break;
+        }
+    }
+    module.set_attribute(c"environ", environment);
+}
+
+unsafe extern "C" fn listdir(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(path) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"path must be a string");
+    };
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return os_error(c"listdir failed");
+    };
+    let mut names = Vec::new();
+    for entry in entries {
+        let Ok(entry) = entry else {
+            return os_error(c"listdir failed");
+        };
+        if let Some(name) = entry.file_name().to_str() {
+            names.push(name.to_owned());
+        }
+    }
+    return_string_list(&names)
+}
+
+unsafe extern "C" fn mkdir(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(path) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"path must be a string");
+    };
+    match std::fs::create_dir(path) {
+        Ok(()) => return_none(),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return_none(),
+        Err(_) => os_error(c"mkdir failed"),
+    }
+}
+
+unsafe extern "C" fn makedirs(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(path) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"name must be a string");
+    };
+    let exist_ok = arguments.get(2).and_then(Value::boolean).unwrap_or(false);
+    if std::path::Path::new(&path).exists() && !exist_ok {
+        return os_error(c"makedirs failed");
+    }
+    match std::fs::create_dir_all(&path) {
+        Ok(()) => return_none(),
+        Err(_) => os_error(c"makedirs failed"),
+    }
+}
+
+unsafe extern "C" fn remove(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Some(path) = one_path(argc, argv) else {
+        return false;
+    };
+    match std::fs::remove_file(path) {
+        Ok(()) => return_none(),
+        Err(_) => os_error(c"remove failed"),
+    }
+}
+
+unsafe extern "C" fn rmdir(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Some(path) = one_path(argc, argv) else {
+        return false;
+    };
+    match std::fs::remove_dir(path) {
+        Ok(()) => return_none(),
+        Err(_) => os_error(c"rmdir failed"),
+    }
+}
+
+unsafe extern "C" fn stat(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Some(path) = one_path(argc, argv) else {
+        return false;
+    };
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return os_error(c"stat failed");
+    };
+    let mut roots = RootFrame::new();
+    let Some(result) = roots.tuple(7) else {
+        return os_error(c"stat failed");
+    };
+    let values = [
+        i64::from(metadata.mode()),
+        0,
+        0,
+        0,
+        0,
+        0,
+        i64::try_from(metadata.len()).unwrap_or(i64::MAX),
+    ];
+    for (index, value) in values.into_iter().enumerate() {
+        let value = roots.integer(value);
+        assert!(
+            result.tuple_set(index, value),
+            "new stat tuple index is valid"
+        );
+    }
+    return_value(result)
+}
+
+fn one_path(argc: c_int, argv: ffi::py_StackRef) -> Option<String> {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return None;
+    }
+    let Some(path) = arguments.get(0).and_then(Value::string) else {
+        type_error(c"path must be a string");
+        return None;
+    };
+    Some(path)
+}
+
+fn return_none() -> bool {
+    let mut roots = RootFrame::new();
+    let none = roots.none();
+    return_value(none)
+}

--- a/crates/ucharm-runtime/src/modules/os_path.rs
+++ b/crates/ucharm-runtime/src/modules/os_path.rs
@@ -1,0 +1,136 @@
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{NativeModule, NativeModuleKind, Value, execute_module};
+
+const COMPATIBILITY_SOURCE: &str = r#"
+import os
+
+
+def exists(path):
+    try:
+        os.stat(path)
+        return True
+    except OSError:
+        return False
+
+
+def isdir(path):
+    try:
+        return (os.stat(path)[0] & 0o170000) == 0o040000
+    except OSError:
+        return False
+
+
+def isfile(path):
+    try:
+        return (os.stat(path)[0] & 0o170000) == 0o100000
+    except OSError:
+        return False
+
+
+def isabs(path):
+    return len(path) > 0 and path[0] == "/"
+
+
+def join(*paths):
+    result = ""
+    for path in paths:
+        if path == "":
+            continue
+        if isabs(path):
+            result = path
+        elif result == "" or result[-1] == "/":
+            result += path
+        else:
+            result += "/" + path
+    return result
+
+
+def split(path):
+    index = len(path) - 1
+    while index >= 0 and path[index] != "/":
+        index -= 1
+    if index < 0:
+        return ("", path)
+    head = path[:index]
+    if head == "" and index == 0:
+        head = "/"
+    return (head, path[index + 1:])
+
+
+def basename(path):
+    return split(path)[1]
+
+
+def dirname(path):
+    return split(path)[0]
+
+
+def splitext(path):
+    slash = -1
+    dot = -1
+    index = 0
+    while index < len(path):
+        if path[index] == "/":
+            slash = index
+        elif path[index] == ".":
+            dot = index
+        index += 1
+    if dot <= slash + 1:
+        return (path, "")
+    return (path[:dot], path[dot:])
+
+
+def normpath(path):
+    if path == "":
+        return "."
+    absolute = isabs(path)
+    output = []
+    for part in path.split("/"):
+        if part == "" or part == ".":
+            continue
+        if part == "..":
+            if len(output) > 0 and output[-1] != "..":
+                output.pop()
+            elif not absolute:
+                output.append(part)
+        else:
+            output.append(part)
+    result = "/".join(output)
+    if absolute:
+        result = "/" + result
+    if result == "":
+        return "/" if absolute else "."
+    return result
+
+
+def abspath(path):
+    if isabs(path):
+        return normpath(path)
+    return normpath(join(os.getcwd(), path))
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"os.path",
+    kind: NativeModuleKind::Create,
+    functions: &[],
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, COMPATIBILITY_SOURCE) {
+        // SAFETY: initialization failed with a live PocketPy exception.
+        unsafe { ffi::py_printexc() };
+        panic!("embedded os.path compatibility layer failed");
+    }
+    // SAFETY: importing `os` earlier in registration created a VM-global
+    // module which remains live for the process lifetime.
+    let os = unsafe { ffi::py_getmodule(c"os".as_ptr()) };
+    assert!(!os.is_null(), "PocketPy os module is missing");
+    // SAFETY: the non-null module reference is VM-global.
+    let os = unsafe { Value::from_raw(os) };
+    os.set_attribute(c"path", module);
+}

--- a/crates/ucharm-runtime/src/modules/pathlib.rs
+++ b/crates/ucharm-runtime/src/modules/pathlib.rs
@@ -1,0 +1,110 @@
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{NativeModule, NativeModuleKind, Value, execute_module};
+
+const COMPATIBILITY_SOURCE: &str = r#"
+import os
+
+
+def _join_paths(paths):
+    result = ""
+    first = True
+    for raw in paths:
+        if not isinstance(raw, str):
+            raise TypeError("path must be a string")
+        part = raw
+        if first:
+            result = part
+            first = False
+            continue
+        while len(part) > 0 and part[0] == "/":
+            part = part[1:]
+        if result != "" and result[-1] != "/":
+            result += "/"
+        result += part
+    while len(result) > 1 and result[-1] == "/":
+        result = result[:-1]
+    return result
+
+
+class Path:
+    def __init__(self, *paths):
+        self.path = _join_paths(paths)
+        display = self.path if self.path != "" else "."
+        if display == "/":
+            self.name = ""
+        else:
+            self.name = os.path.basename(display)
+        root, suffix = os.path.splitext(self.name)
+        self.suffix = suffix
+        self.stem = root if suffix != "" else self.name
+        parent_path = os.path.dirname(display)
+        if parent_path == "":
+            parent_path = "."
+        if parent_path == display:
+            self.parent = self
+        else:
+            self.parent = Path(parent_path)
+
+    def __str__(self):
+        return self.path if self.path != "" else "."
+
+    def __repr__(self):
+        return "Path('" + str(self) + "')"
+
+    def __truediv__(self, other):
+        return Path(self.path, other)
+
+    def joinpath(self, *others):
+        values = [self.path]
+        for other in others:
+            values.append(other)
+        return Path(*values)
+
+    def with_name(self, name):
+        return Path(str(self.parent), name)
+
+    def with_suffix(self, suffix):
+        if not isinstance(suffix, str):
+            raise TypeError("suffix must be a string")
+        base = self.path
+        if self.suffix != "":
+            base = base[:-len(self.suffix)]
+        return Path(base + suffix)
+
+    def is_absolute(self):
+        return os.path.isabs(self.path)
+
+    def exists(self):
+        return os.path.exists(str(self))
+
+    def is_file(self):
+        return os.path.isfile(str(self))
+
+    def is_dir(self):
+        return os.path.isdir(str(self))
+
+    def resolve(self):
+        return Path(os.path.abspath(str(self)))
+
+    def cwd():
+        return Path(os.getcwd())
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"pathlib",
+    kind: NativeModuleKind::Create,
+    functions: &[],
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, COMPATIBILITY_SOURCE) {
+        // SAFETY: initialization failed with a live PocketPy exception.
+        unsafe { ffi::py_printexc() };
+        panic!("embedded pathlib compatibility layer failed");
+    }
+}

--- a/crates/ucharm-runtime/src/modules/shutil.rs
+++ b/crates/ucharm-runtime/src/modules/shutil.rs
@@ -1,0 +1,110 @@
+use std::ffi::c_int;
+
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{
+    Arguments, NativeFunction, NativeModule, NativeModuleKind, RootFrame, Value, os_error,
+    return_string, return_value, type_error,
+};
+
+const FUNCTIONS: &[NativeFunction] = &[
+    NativeFunction {
+        name: c"copy",
+        callback: copy,
+    },
+    NativeFunction {
+        name: c"move",
+        callback: move_path,
+    },
+    NativeFunction {
+        name: c"rmtree",
+        callback: rmtree,
+    },
+    NativeFunction {
+        name: c"exists",
+        callback: exists,
+    },
+];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"shutil",
+    kind: NativeModuleKind::Create,
+    functions: FUNCTIONS,
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: None,
+};
+
+unsafe extern "C" fn copy(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Some((source, destination)) = two_paths(argc, argv) else {
+        return false;
+    };
+    match std::fs::copy(&source, &destination) {
+        Ok(_) => return_string(&destination),
+        Err(_) => os_error(c"copy failed"),
+    }
+}
+
+unsafe extern "C" fn move_path(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Some((source, destination)) = two_paths(argc, argv) else {
+        return false;
+    };
+    if std::fs::rename(&source, &destination).is_err()
+        && (std::fs::copy(&source, &destination).is_err() || std::fs::remove_file(&source).is_err())
+    {
+        return os_error(c"move failed");
+    }
+    return_string(&destination)
+}
+
+unsafe extern "C" fn rmtree(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Some(path) = one_path(argc, argv) else {
+        return false;
+    };
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => {
+            let mut roots = RootFrame::new();
+            let none = roots.none();
+            return_value(none)
+        }
+        Err(_) => os_error(c"rmtree failed"),
+    }
+}
+
+unsafe extern "C" fn exists(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Some(path) = one_path(argc, argv) else {
+        return false;
+    };
+    let mut roots = RootFrame::new();
+    let value = roots.boolean(std::path::Path::new(&path).exists());
+    return_value(value)
+}
+
+fn one_path(argc: c_int, argv: ffi::py_StackRef) -> Option<String> {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return None;
+    }
+    let Some(path) = arguments.get(0).and_then(Value::string) else {
+        type_error(c"path must be a string");
+        return None;
+    };
+    Some(path)
+}
+
+fn two_paths(argc: c_int, argv: ffi::py_StackRef) -> Option<(String, String)> {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(2, 2) {
+        return None;
+    }
+    let Some(source) = arguments.get(0).and_then(Value::string) else {
+        type_error(c"src must be a string");
+        return None;
+    };
+    let Some(destination) = arguments.get(1).and_then(Value::string) else {
+        type_error(c"dst must be a string");
+        return None;
+    };
+    Some((source, destination))
+}

--- a/crates/ucharm-runtime/src/modules/string_methods.rs
+++ b/crates/ucharm-runtime/src/modules/string_methods.rs
@@ -2,13 +2,21 @@ use std::ffi::c_int;
 
 use ucharm_pocketpy_sys as ffi;
 
-use crate::native::{Arguments, RootFrame, bind_type_method, return_value, type_error};
+use crate::native::{
+    Arguments, RootFrame, Value, bind_type_method, bind_type_signature, return_string_list,
+    return_value, type_error, value_error,
+};
 
 pub(super) fn register() {
     bind_type_method(
         ffi::py_PredefinedType_tp_str as ffi::py_Type,
         c"isupper",
         isupper,
+    );
+    bind_type_signature(
+        ffi::py_PredefinedType_tp_str as ffi::py_Type,
+        c"rsplit(self, sep=None, maxsplit=-1)",
+        rsplit,
     );
 }
 
@@ -35,4 +43,36 @@ unsafe extern "C" fn isupper(argc: c_int, argv: ffi::py_StackRef) -> bool {
     let mut roots = RootFrame::new();
     let result = roots.boolean(has_cased);
     return_value(result)
+}
+
+unsafe extern "C" fn rsplit(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(value) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"expected string");
+    };
+    let Some(separator) = arguments.get(1).and_then(Value::string) else {
+        return type_error(c"separator must be a string");
+    };
+    if separator.is_empty() {
+        return value_error(c"empty separator");
+    }
+    let maxsplit = arguments.get(2).and_then(Value::integer).unwrap_or(-1);
+    let mut values = if maxsplit < 0 {
+        value
+            .split(&separator)
+            .map(str::to_owned)
+            .collect::<Vec<_>>()
+    } else {
+        let count = usize::try_from(maxsplit).unwrap_or(usize::MAX);
+        let mut values = value
+            .rsplitn(count.saturating_add(1), &separator)
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        values.reverse();
+        values
+    };
+    if values.is_empty() {
+        values.push(value);
+    }
+    return_string_list(&values)
 }

--- a/crates/ucharm-runtime/src/modules/tempfile.rs
+++ b/crates/ucharm-runtime/src/modules/tempfile.rs
@@ -1,0 +1,117 @@
+use std::ffi::c_int;
+use std::fs::OpenOptions;
+
+use ucharm_pocketpy_sys as ffi;
+
+use super::filesystem_core;
+use crate::native::{
+    Arguments, NativeFunction, NativeModule, NativeModuleKind, NativeSignature, os_error,
+    return_string, type_error,
+};
+
+const FUNCTIONS: &[NativeFunction] = &[
+    NativeFunction {
+        name: c"gettempdir",
+        callback: gettempdir,
+    },
+    NativeFunction {
+        name: c"mktemp",
+        callback: mktemp,
+    },
+    NativeFunction {
+        name: c"mkstemp",
+        callback: mkstemp,
+    },
+];
+
+const SIGNATURES: &[NativeSignature] = &[NativeSignature {
+    signature: c"mkdtemp(prefix=None)",
+    callback: mkdtemp,
+}];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"tempfile",
+    kind: NativeModuleKind::Create,
+    functions: FUNCTIONS,
+    signatures: SIGNATURES,
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: None,
+};
+
+unsafe extern "C" fn gettempdir(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(0, 0) {
+        return false;
+    }
+    return_path(filesystem_core::temporary_directory())
+}
+
+unsafe extern "C" fn mktemp(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(0, 0) {
+        return false;
+    }
+    let prefix = filesystem_core::temporary_directory().join("tmp");
+    for _ in 0..1000 {
+        let candidate = filesystem_core::unique_path(&prefix.to_string_lossy());
+        if !candidate.exists() {
+            return return_path(candidate);
+        }
+    }
+    os_error(c"mktemp failed")
+}
+
+unsafe extern "C" fn mkstemp(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(0, 0) {
+        return false;
+    }
+    let prefix = filesystem_core::temporary_directory().join("tmp");
+    for _ in 0..1000 {
+        let candidate = filesystem_core::unique_path(&prefix.to_string_lossy());
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(file) => {
+                drop(file);
+                return return_path(candidate);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(_) => return os_error(c"mkstemp failed"),
+        }
+    }
+    os_error(c"mkstemp failed")
+}
+
+unsafe extern "C" fn mkdtemp(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let prefix = match arguments.get(0) {
+        None => filesystem_core::temporary_directory().join("tmp"),
+        Some(value) if value.is_none() => filesystem_core::temporary_directory().join("tmp"),
+        Some(value) => {
+            let Some(prefix) = value.string() else {
+                return type_error(c"prefix must be a string");
+            };
+            std::path::PathBuf::from(prefix)
+        }
+    };
+    for _ in 0..1000 {
+        let candidate = filesystem_core::unique_path(&prefix.to_string_lossy());
+        match std::fs::create_dir(&candidate) {
+            Ok(()) => return return_path(candidate),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(_) => return os_error(c"mkdtemp failed"),
+        }
+    }
+    os_error(c"mkdtemp failed")
+}
+
+fn return_path(path: std::path::PathBuf) -> bool {
+    let Some(path) = filesystem_core::path_string(&path) else {
+        return os_error(c"temporary path is not valid UTF-8");
+    };
+    return_string(&path)
+}

--- a/crates/ucharm-runtime/src/native.rs
+++ b/crates/ucharm-runtime/src/native.rs
@@ -984,6 +984,18 @@ pub(crate) fn runtime_error(message: &'static CStr) -> bool {
     }
 }
 
+pub(crate) fn os_error(message: &'static CStr) -> bool {
+    // SAFETY: the VM is active during a callback. The format string and message
+    // have static storage and match PocketPy's `%s` vararg contract.
+    unsafe {
+        ffi::py_exception(
+            ffi::py_PredefinedType_tp_OSError as ffi::py_Type,
+            c"%s".as_ptr(),
+            message.as_ptr(),
+        )
+    }
+}
+
 pub(crate) fn value_error(message: &'static CStr) -> bool {
     // SAFETY: the VM is active during a callback. The format string and message
     // have static storage and match PocketPy's `%s` vararg contract.

--- a/crates/ucharm-runtime/tests/filesystem_wave.rs
+++ b/crates/ucharm-runtime/tests/filesystem_wave.rs
@@ -1,0 +1,162 @@
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+#[test]
+fn passes_all_filesystem_wave_compatibility_fixtures() {
+    for (module, source, summary) in [
+        (
+            "os",
+            include_str!("../../../tests/cpython/test_os.py"),
+            "Results: 45 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "glob",
+            include_str!("../../../tests/cpython/test_glob.py"),
+            "Results: 4 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "tempfile",
+            include_str!("../../../tests/cpython/test_tempfile.py"),
+            "Results: 12 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "shutil",
+            include_str!("../../../tests/cpython/test_shutil.py"),
+            "Results: 8 passed, 0 failed, 0 skipped",
+        ),
+    ] {
+        let output = run_runtime(source);
+        assert!(
+            output.status.success(),
+            "{module} fixture failed:\n{}",
+            diagnostic(&output)
+        );
+        assert!(
+            text(&output.stdout).contains(summary),
+            "{module} summary missing:\n{}",
+            diagnostic(&output)
+        );
+        assert_eq!(text(&output.stderr), "", "{module}");
+    }
+
+    let pathlib = fixture_path("test_pathlib.py");
+    let output = run_file(&pathlib);
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert!(
+        text(&output.stdout).contains("Results: 40 passed, 0 failed, 0 skipped"),
+        "{}",
+        diagnostic(&output)
+    );
+    assert_eq!(text(&output.stderr), "");
+}
+
+#[test]
+fn matches_cpython_for_deterministic_path_operations() {
+    let source = concat!(
+        "import os\n",
+        "from pathlib import Path\n",
+        "print(os.path.join('alpha', 'beta', 'file.tar.gz'))\n",
+        "print(os.path.split('/alpha/beta.txt'))\n",
+        "print(os.path.splitext('/alpha/file.tar.gz'))\n",
+        "print(os.path.normpath('/alpha/./beta/../gamma'))\n",
+        "path = Path('/alpha', 'beta', 'file.tar.gz')\n",
+        "print(str(path))\n",
+        "print(path.name, path.stem, path.suffix, str(path.parent))\n",
+        "print(str(path.with_name('other.txt')))\n",
+        "print(str(path.with_suffix('.zip')))\n",
+        "print(path.is_absolute())\n",
+    );
+    let rust = run_runtime(source);
+    assert!(rust.status.success(), "{}", diagnostic(&rust));
+    let cpython = Command::new("python3")
+        .args(["-c", source])
+        .output()
+        .expect("run CPython differential oracle");
+    assert!(cpython.status.success(), "{}", diagnostic(&cpython));
+    assert_eq!(rust.stdout, cpython.stdout);
+    assert_eq!(text(&rust.stderr), "");
+}
+
+#[test]
+fn preserves_recursive_filesystem_lifecycle_and_errors_under_stress() {
+    let output = run_runtime(concat!(
+        "import glob, os, shutil, tempfile\n",
+        "from pathlib import Path\n",
+        "root = tempfile.mkdtemp('/tmp/ucharm_fs_wave_')\n",
+        "nested = os.path.join(root, 'a', 'b')\n",
+        "os.makedirs(nested, exist_ok=True)\n",
+        "for i in range(200):\n",
+        "    path = os.path.join(nested, 'item' + str(i) + '.txt')\n",
+        "    with open(path, 'w') as output:\n",
+        "        output.write('value-' + str(i))\n",
+        "matches = glob.glob(os.path.join(root, '**', '*.txt'), None, None, True)\n",
+        "assert len(matches) == 200\n",
+        "assert Path(nested).exists() and Path(nested).is_dir()\n",
+        "source = os.path.join(nested, 'item0.txt')\n",
+        "copied = os.path.join(root, 'copied.txt')\n",
+        "moved = os.path.join(root, 'moved.txt')\n",
+        "assert shutil.copy(source, copied) == copied\n",
+        "assert shutil.move(copied, moved) == moved\n",
+        "assert Path(moved).is_file() and not Path(copied).exists()\n",
+        "assert os.path.abspath('.') == str(Path('.').resolve())\n",
+        "for operation in (\n",
+        "    lambda: os.stat(os.path.join(root, 'missing')),\n",
+        "    lambda: os.remove(os.path.join(root, 'missing')),\n",
+        "    lambda: os.listdir(os.path.join(root, 'missing')),\n",
+        "):\n",
+        "    caught = False\n",
+        "    try:\n",
+        "        operation()\n",
+        "    except OSError:\n",
+        "        caught = True\n",
+        "    assert caught\n",
+        "shutil.rmtree(root)\n",
+        "assert not os.path.exists(root)\n",
+    ));
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(text(&output.stderr), "");
+}
+
+#[test]
+fn exposes_script_file_to_python() {
+    let path = std::env::temp_dir().join(format!("ucharm-file-test-{}.py", std::process::id()));
+    std::fs::write(&path, "print(__file__)").expect("write temporary script");
+    let output = run_file(&path);
+    std::fs::remove_file(&path).expect("remove temporary script");
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(text(&output.stdout).trim(), path.to_string_lossy());
+    assert_eq!(text(&output.stderr), "");
+}
+
+fn run_runtime(source: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pocketpy-ucharm-rs"))
+        .args(["-c", source])
+        .output()
+        .expect("run Rust PocketPy runtime")
+}
+
+fn run_file(path: &std::path::Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pocketpy-ucharm-rs"))
+        .arg(path)
+        .output()
+        .expect("run Rust PocketPy script")
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/cpython")
+        .join(name)
+}
+
+fn text(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn diagnostic(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        text(&output.stdout),
+        text(&output.stderr)
+    )
+}

--- a/tests/compat_report_pocketpy.md
+++ b/tests/compat_report_pocketpy.md
@@ -1,14 +1,14 @@
 # μcharm Compatibility Report
 
-Generated: 2026-08-04 18:40:11
+Generated: 2026-08-04 18:57:31
 
 ## Summary
 
 ### Targeted Modules
 
-- **Tests passing**: 1,185/1,668 (71.0%)
-- **Modules at 100%**: 30/52
-- **Modules partial**: 6/52
+- **Tests passing**: 1,285/1,668 (77.0%)
+- **Modules at 100%**: 35/52
+- **Modules partial**: 5/52
 - **No baseline (host CPython)**: 1/52
 
 ### CPython Stdlib Coverage
@@ -33,6 +33,7 @@ Generated: 2026-08-04 18:40:11
 | errno | stdlib | 38/38 | 38/38 | 100% | ✅ Full |
 | fnmatch | stdlib | 55/55 | 55/55 | 100% | ✅ Full |
 | functools | stdlib | 40/40 | 40/40 | 100% | ✅ Full |
+| glob | stdlib | 3/3 | 3/3 | 100% | ✅ Full |
 | gzip | stdlib | 6/6 | 6/6 | 100% | ✅ Full |
 | hashlib | stdlib | 29/29 | 29/29 | 100% | ✅ Full |
 | heapq | stdlib | 42/42 | 42/42 | 100% | ✅ Full |
@@ -41,11 +42,15 @@ Generated: 2026-08-04 18:40:11
 | itertools | stdlib | 33/33 | 33/33 | 100% | ✅ Full |
 | json | stdlib | 70/70 | 70/70 | 100% | ✅ Full |
 | operator | stdlib | 114/115 | 115/115 | 100% | ✅ Full |
+| os | stdlib | 45/45 | 45/45 | 100% | ✅ Full |
+| pathlib | stdlib | 40/40 | 40/40 | 100% | ✅ Full |
 | random | stdlib | 46/46 | 46/46 | 100% | ✅ Full |
 | secrets | stdlib | 8/8 | 8/8 | 100% | ✅ Full |
+| shutil | stdlib | 6/6 | 6/6 | 100% | ✅ Full |
 | statistics | stdlib | 28/28 | 28/28 | 100% | ✅ Full |
 | struct | stdlib | 68/68 | 68/68 | 100% | ✅ Full |
 | tarfile | stdlib | 7/7 | 7/7 | 100% | ✅ Full |
+| tempfile | stdlib | 9/9 | 9/9 | 100% | ✅ Full |
 | textwrap | stdlib | 24/24 | 24/24 | 100% | ✅ Full |
 | toml | stdlib | - | - | - | ✅ Full |
 | typing | stdlib | 43/43 | 43/43 | 100% | ✅ Full |
@@ -53,22 +58,17 @@ Generated: 2026-08-04 18:40:11
 | zipfile | stdlib | 7/7 | 7/7 | 100% | ✅ Full |
 | math | stdlib | 82/82 | 73/82 | 89% | 9 skipped |
 | time | stdlib | 42/42 | 22/42 | 52% | 6 skipped |
-| os | stdlib | 45/45 | 3/45 | 7% |  |
 | sys | stdlib | 58/58 | 3/58 | 5% | 1 failing |
 | urllib_parse | stdlib | 24/24 | 1/24 | 4% | 1 skipped |
 | configparser | stdlib | 26/26 | 1/26 | 4% | 1 skipped |
 | argparse | stdlib | 26/26 | 0/26 | 0% | 1 skipped |
 | contextlib | stdlib | 10/10 | 0/10 | 0% | 1 failing |
-| glob | stdlib | 3/3 | 0/3 | 0% | 1 failing |
 | http.client | stdlib | 8/8 | 0/8 | 0% |  |
 | logging | stdlib | 39/39 | 0/39 | 0% | 1 failing |
-| pathlib | stdlib | 40/40 | 0/40 | 0% | 1 skipped |
 | re | stdlib | 79/79 | 0/79 | 0% | 1 failing |
-| shutil | stdlib | 6/6 | 0/6 | 0% | 1 failing |
 | signal | stdlib | 15/15 | 0/15 | 0% | 1 failing |
 | sqlite3 | stdlib | 2/2 | 0/2 | 0% |  |
 | subprocess | stdlib | 19/19 | 0/19 | 0% | 1 failing |
-| tempfile | stdlib | 9/9 | 0/9 | 0% | 1 failing |
 | tomllib | stdlib | 0/1 | 0/1 | 0% |  |
 | unittest | stdlib | 40/40 | 0/40 | 0% | 1 skipped |
 | xml.etree.ElementTree | stdlib | 12/12 | 0/12 | 0% |  |
@@ -94,22 +94,7 @@ Generated: 2026-08-04 18:40:11
 
 - `FAIL: version_info exists`
 
-### glob
-
-- `error: Python execution failed
-`
-
 ### logging
-
-- `error: Python execution failed
-`
-
-### pathlib
-
-- `error: Python execution failed
-`
-
-### shutil
 
 - `error: Python execution failed
 `
@@ -120,11 +105,6 @@ Generated: 2026-08-04 18:40:11
 `
 
 ### subprocess
-
-- `error: Python execution failed
-`
-
-### tempfile
 
 - `error: Python execution failed
 `
@@ -172,10 +152,6 @@ These tests require features not available in pocketpy-ucharm:
 - 6 tests skipped
 
 ### urllib_parse
-
-- 1 tests skipped
-
-### pathlib
 
 - 1 tests skipped
 


### PR DESCRIPTION
## What changed

- port `os`, `os.path`, `pathlib`, `glob`, `tempfile`, and `shutil` to the Rust-hosted PocketPy runtime
- expose the process environment and script `__file__`, and add the narrow `str.rsplit` prerequisite
- add CPython path differentials, recursive lifecycle/error stress, optimized two-architecture fixture coverage, and four-target CI smoke coverage
- refresh the compatibility report and measured size/startup snapshots
- add the post-cutover README, website, docs, and migration retrospective phase to the roadmap, including the why/how/outcome narrative and reproducible statistics

## Impact

- Rust compatibility rises from 1,185/1,668 (71.0%) to 1,285/1,668 (77.0%)
- five additional targeted modules reach full parity, for 35 full and 5 partial modules
- all five filesystem fixtures pass 109/109 raw checks; the CPython-baselined report gains 100 checks
- optimized ARM64 runtime: 851,888 bytes, 4.298 ms median / 5.241 ms p95 over 400 runs
- optimized x86_64 runtime: 934,784 bytes, 11.107 ms median / 12.113 ms p95 under Rosetta

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- full 1,668-check compatibility report
- all five fixtures and the exact filesystem CI smoke on optimized ARM64 and x86_64 macOS binaries

Tracks #13.
