### PR TITLE
Port the Rust tooling and format wave

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,6 +93,11 @@ jobs:
         run: >-
           target/${{ matrix.target }}/release/pocketpy-ucharm-rs
           -c 'import logging, re, signal, subprocess; found = re.search(r"(item)-(\d+)", "prefix item-42"); assert found.groups() == ("item", "42"); assert re.sub(r"(\w+)", r"[\1]", "hello") == "[hello]"; logger = logging.getLogger("smoke.child"); assert logger is logging.getLogger("smoke.child"); signal.signal(signal.SIGUSR1, signal.SIG_IGN); assert signal.getsignal(signal.SIGUSR1) == signal.SIG_IGN; result = subprocess.run(["sh", "-c", "printf ucharm"], capture_output=True); assert result["returncode"] == 0 and result["stdout"] == b"ucharm"'
+      - name: Smoke-test Rust tooling-format wave
+        shell: bash
+        run: >-
+          target/${{ matrix.target }}/release/pocketpy-ucharm-rs
+          -c 'import argparse, configparser, contextlib, tomllib, unittest; from urllib.parse import quote, unquote; from xml.etree.ElementTree import fromstring, tostring; parser = argparse.ArgumentParser(); parser.add_argument("--count", type=int, required=True); assert parser.parse_args(["--count", "3"]).count == 3; config = configparser.ConfigParser(); config.read_string("[core]\nenabled=yes\n"); assert config.getboolean("core", "enabled"); assert unquote(quote("μ charm")) == "μ charm"; assert tomllib.loads("name=\"ucharm\"")["name"] == "ucharm"; xml = fromstring("<root><child>a &lt; b</child></root>"); assert "a &lt; b" in tostring(xml, "unicode"); case = unittest.TestCase(); case.assertEqual(2 + 2, 4); assert contextlib.nullcontext("ok").__enter__() == "ok"'
       - name: Smoke-test Rust CLI
         shell: bash
         run: target/${{ matrix.target }}/release/ucharm-rs --version | grep -q "μcharm"

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,9 +5,9 @@ This is the single source of truth for priorities and next steps.
 ## Snapshot
 
 - Goal: build beautiful CLI apps with Python syntax, shipped as tiny, fast binaries.
-- Runtime: PocketPy; the Rust host, loader, CLI, and 39 fully compatible stdlib targets are implemented while the remaining native modules migrate from Zig.
+- Runtime: PocketPy; the Rust host, loader, CLI, and 46 fully compatible stdlib targets are implemented while the remaining native modules migrate from Zig.
 - Language decision: Rust is the target implementation language. See `RUST_MIGRATION.md` for gates and sequencing.
-- Compatibility status: the Rust migration runtime passes 1,437/1,668 checks (86.2%), with 39/52 targeted modules at 100% parity. Refresh with `python3 tests/compat_runner.py --runtime target/debug/pocketpy-ucharm-rs --report`.
+- Compatibility status: the Rust migration runtime passes 1,574/1,668 checks (94.4%), with 46/52 targeted modules at 100% parity. Refresh with `python3 tests/compat_runner.py --runtime target/debug/pocketpy-ucharm-rs --report`.
 - PocketPy vendor patches are tracked under `pocketpy/patches/` and verified via `python3 scripts/verify-pocketpy-patches.py --check-upstream`.
 
 ## Current State (from the repo)

--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ ucharm/
 
 Current compatibility summary (from `tests/compat_report_pocketpy.md`):
 
-- Rust migration runtime: 1,437/1,668 tests passing (86.2%)
-- 52 targeted modules, with 39 at 100% parity on the Rust host
-- 4.558ms median native ARM64 startup and a 970,064-byte stripped runtime in
+- Rust migration runtime: 1,574/1,668 tests passing (94.4%)
+- 52 targeted modules, with 46 at 100% parity on the Rust host
+- 5.222ms median native ARM64 startup and a 986,624-byte stripped runtime in
   the latest 400-run migration sample
 
 ## Showcase

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -196,7 +196,9 @@ status, stdout, and stderr.
   compression, and archive wave: `hashlib`, `hmac`, `gzip`, `io`, `zipfile`,
   and `tarfile`; the filesystem wave: `os`, `os.path`, `pathlib`, `glob`,
   `tempfile`, and `shutil`; and the process/regex/observability wave: `re`,
-  `logging`, `signal`, and `subprocess`.
+  `logging`, `signal`, and `subprocess`; plus the tooling/format wave:
+  `argparse`, `configparser`, `contextlib`, `unittest`, `urllib.parse`,
+  `tomllib`, and `xml.etree.ElementTree`.
   The shared boundary copies PocketPy bytes into owned Rust buffers before
   allocation, roots
   exact-size byte and float results, supports equality and ordered comparison,
@@ -251,16 +253,22 @@ status, stdout, and stderr.
   with concurrent capped stdout/stderr draining. It passes 152/152 fixture
   checks plus CPython regex/process differentials, logger output assertions,
   repeated capture/state stress, invalid-input coverage, 1 MiB-per-stream cap
-  tests, and optimized dual-architecture smoke. The full Rust result is now
-  1,437/1,668 (86.2%), up from the original 456/1,668, with 39 of 52 targeted
+  tests, and optimized dual-architecture smoke. The tooling/format wave keeps
+  parser, test-runner, context-manager, URL, TOML, and XML object state owned
+  by PocketPy, with narrow Rust callbacks only for UTF-8-safe URL and TOML byte
+  conversion. Its seven fixtures pass 142/142 raw checks and add 137 checks to
+  the conservative report, backed by CPython differential output, 250-round
+  nested parser/serializer stress, malformed-input coverage, Unicode URL
+  round-trips, and four-target release smoke. The full Rust result is now
+  1,574/1,668 (94.4%), up from the original 456/1,668, with 46 of 52 targeted
   modules at full parity.
   Related low-risk modules now move as validated waves; standalone PRs are
   reserved for boundaries whose ownership or binary-format risk warrants them.
-- The current stripped macOS runtime is 970,064 bytes on ARM64 and 1,043,792
+- The current stripped macOS runtime is 986,624 bytes on ARM64 and 1,068,424
   bytes on x86_64, versus 2,313,264 bytes for the legacy Zig ARM64 runtime.
-  On the latest 400-run warm-start sample, native Rust measured 4.558 ms median
-  and 5.852 ms p95; x86_64 Rust under Rosetta measured 11.078 ms median and
-  12.325 ms p95. The native ARM64 host remains below the 10 ms gate; native
+  On the latest 400-run warm-start sample, native Rust measured 5.222 ms median
+  and 5.641 ms p95; x86_64 Rust under Rosetta measured 12.347 ms median and
+  14.457 ms p95. The native ARM64 host remains below the 10 ms gate; native
   Intel CI remains the authoritative x86_64 execution environment.
 
 ### Phase 0 — Freeze and baseline

--- a/crates/ucharm-runtime/src/modules/argparse.rs
+++ b/crates/ucharm-runtime/src/modules/argparse.rs
@@ -1,0 +1,202 @@
+use crate::native::{NativeModule, NativeModuleKind, Value, execute_module};
+
+const SOURCE: &str = r#"
+class Namespace:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+class _MutuallyExclusiveGroup:
+    def __init__(self, parser):
+        self.parser = parser
+        self.dests = []
+
+    def add_argument(self, *names, **kwargs):
+        spec = self.parser.add_argument(*names, **kwargs)
+        self.dests.append(spec['dest'])
+        return spec
+
+class _SubParsersAction:
+    def __init__(self, parser, dest):
+        self.parser = parser
+        self.dest = dest
+
+    def add_parser(self, name, **kwargs):
+        child = ArgumentParser(prog=name, **kwargs)
+        self.parser._subparsers[name] = child
+        return child
+
+class ArgumentParser:
+    def __init__(self, prog=None, description=None, **kwargs):
+        self.prog = prog
+        self.description = description
+        self._options = {}
+        self._option_order = []
+        self._positionals = []
+        self._groups = []
+        self._subparsers = {}
+        self._subparser_dest = None
+
+    def add_argument(self, *names, **kwargs):
+        if len(names) == 0:
+            raise TypeError('add_argument() requires a name')
+        first = names[0]
+        is_option = first.startswith('-')
+        dest = kwargs.get('dest')
+        if dest is None:
+            chosen = first
+            for name in names:
+                if name.startswith('--'):
+                    chosen = name
+                    break
+            dest = chosen.lstrip('-').replace('-', '_')
+        spec = {
+            'names': names,
+            'dest': dest,
+            'type': kwargs.get('type'),
+            'default': kwargs.get('default'),
+            'has_default': 'default' in kwargs,
+            'action': kwargs.get('action'),
+            'nargs': kwargs.get('nargs'),
+            'const': kwargs.get('const'),
+            'choices': kwargs.get('choices'),
+            'required': kwargs.get('required', False),
+            'help': kwargs.get('help'),
+        }
+        if is_option:
+            self._option_order.append(spec)
+            for name in names:
+                self._options[name] = spec
+        else:
+            self._positionals.append(spec)
+        return spec
+
+    def add_mutually_exclusive_group(self, **kwargs):
+        group = _MutuallyExclusiveGroup(self)
+        self._groups.append(group.dests)
+        return group
+
+    def add_subparsers(self, dest=None, **kwargs):
+        self._subparser_dest = dest
+        return _SubParsersAction(self, dest)
+
+    def _convert(self, spec, value):
+        converter = spec['type']
+        result = converter(value) if converter is not None else value
+        choices = spec['choices']
+        if choices is not None and result not in choices:
+            raise SystemExit('invalid choice')
+        return result
+
+    def parse_args(self, args=None):
+        if args is None:
+            import sys
+            args = sys.argv[1:]
+        args = list(args)
+        if len(args) > 0 and args[0] in self._subparsers:
+            command = args[0]
+            namespace = self._subparsers[command].parse_args(args[1:])
+            if self._subparser_dest is not None:
+                setattr(namespace, self._subparser_dest, command)
+            return namespace
+
+        namespace = Namespace()
+        seen = {}
+        for spec in self._option_order:
+            action = spec['action']
+            if spec['has_default']:
+                value = spec['default']
+            elif action == 'store_true':
+                value = False
+            elif action == 'store_false':
+                value = True
+            else:
+                value = None
+            setattr(namespace, spec['dest'], value)
+
+        positional_values = []
+        index = 0
+        while index < len(args):
+            token = args[index]
+            if token.startswith('-'):
+                if token not in self._options:
+                    raise SystemExit('unknown option')
+                spec = self._options[token]
+                dest = spec['dest']
+                for group in self._groups:
+                    if dest in group:
+                        for other in group:
+                            if other != dest and other in seen:
+                                raise SystemExit('mutually exclusive options')
+                action = spec['action']
+                nargs = spec['nargs']
+                if action == 'store_true':
+                    value = True
+                    index += 1
+                elif action == 'store_false':
+                    value = False
+                    index += 1
+                elif nargs == '*':
+                    value = []
+                    index += 1
+                    while index < len(args) and not args[index].startswith('-'):
+                        value.append(self._convert(spec, args[index]))
+                        index += 1
+                elif nargs == '?':
+                    index += 1
+                    if index >= len(args) or args[index].startswith('-'):
+                        value = spec['const']
+                    else:
+                        value = self._convert(spec, args[index])
+                        index += 1
+                else:
+                    if index + 1 >= len(args):
+                        raise SystemExit('expected one argument')
+                    value = self._convert(spec, args[index + 1])
+                    index += 2
+                setattr(namespace, dest, value)
+                seen[dest] = True
+            else:
+                positional_values.append(token)
+                index += 1
+
+        position = 0
+        for spec in self._positionals:
+            nargs = spec['nargs']
+            if nargs == '*' or nargs == '+':
+                values = []
+                while position < len(positional_values):
+                    values.append(self._convert(spec, positional_values[position]))
+                    position += 1
+                if nargs == '+' and len(values) == 0:
+                    raise SystemExit('required positional missing')
+                setattr(namespace, spec['dest'], values)
+                seen[spec['dest']] = True
+            else:
+                if position >= len(positional_values):
+                    raise SystemExit('required positional missing')
+                setattr(namespace, spec['dest'], self._convert(spec, positional_values[position]))
+                seen[spec['dest']] = True
+                position += 1
+        if position != len(positional_values):
+            raise SystemExit('unrecognized arguments')
+
+        for spec in self._option_order:
+            if spec['required'] and spec['dest'] not in seen:
+                raise SystemExit('required option missing')
+        return namespace
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"argparse",
+    kind: NativeModuleKind::Create,
+    functions: &[],
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    assert!(execute_module(module, SOURCE), "embedded argparse module");
+}

--- a/crates/ucharm-runtime/src/modules/configparser.rs
+++ b/crates/ucharm-runtime/src/modules/configparser.rs
@@ -1,0 +1,72 @@
+use crate::native::{NativeModule, NativeModuleKind, Value, execute_module};
+
+const SOURCE: &str = r#"
+class ConfigParser:
+    def __init__(self):
+        self._sections = {}
+        self._order = []
+
+    def read_string(self, text):
+        self._sections = {}
+        self._order = []
+        current = None
+        for raw in text.split('\n'):
+            line = raw.strip()
+            if not line or line.startswith('#') or line.startswith(';'):
+                continue
+            if line.startswith('[') and line.endswith(']'):
+                current = line[1:-1].strip()
+                if current not in self._sections:
+                    self._sections[current] = {}
+                    self._order.append(current)
+                continue
+            if '=' not in line or current is None:
+                raise ValueError('invalid configuration line')
+            index = line.index('=')
+            key = line[:index].strip()
+            value = line[index + 1:].strip()
+            self._sections[current][key] = value
+
+    def sections(self):
+        return list(self._order)
+
+    def get(self, section, option):
+        return self._sections[section][option]
+
+    def getint(self, section, option):
+        return int(self.get(section, option))
+
+    def getfloat(self, section, option):
+        return float(self.get(section, option))
+
+    def getboolean(self, section, option):
+        value = self.get(section, option).lower()
+        if value in ('1', 'yes', 'true', 'on'):
+            return True
+        if value in ('0', 'no', 'false', 'off'):
+            return False
+        raise ValueError('invalid boolean')
+
+    def has_section(self, section):
+        return section in self._sections
+
+    def has_option(self, section, option):
+        return section in self._sections and option in self._sections[section]
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"configparser",
+    kind: NativeModuleKind::Create,
+    functions: &[],
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    assert!(
+        execute_module(module, SOURCE),
+        "embedded configparser module"
+    );
+}

--- a/crates/ucharm-runtime/src/modules/contextlib.rs
+++ b/crates/ucharm-runtime/src/modules/contextlib.rs
@@ -1,0 +1,81 @@
+use crate::native::{NativeModule, NativeModuleKind, Value, execute_module};
+
+const SOURCE: &str = r#"
+class _GeneratorContextManager:
+    def __init__(self, func, args, kwargs):
+        self.gen = func(*args, **kwargs)
+
+    def __enter__(self):
+        try:
+            return next(self.gen)
+        except StopIteration:
+            raise RuntimeError("generator didn't yield")
+
+    def __exit__(self, *args):
+        try:
+            next(self.gen)
+        except StopIteration:
+            return False
+        raise RuntimeError("generator didn't stop")
+
+class _ContextManagerWrapper:
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        return _GeneratorContextManager(self.func, args, kwargs)
+
+def contextmanager(func):
+    return _ContextManagerWrapper(func)
+
+class closing:
+    def __init__(self, thing):
+        self.thing = thing
+
+    def __enter__(self):
+        return self.thing
+
+    def __exit__(self, *exc_info):
+        self.thing.close()
+        return False
+
+class suppress:
+    def __init__(self, *exceptions):
+        self._exceptions = exceptions
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        exctype = args[0] if len(args) > 0 else None
+        if exctype is None:
+            return False
+        for exc in self._exceptions:
+            if issubclass(exctype, exc):
+                return True
+        return False
+
+class nullcontext:
+    def __init__(self, enter_result=None):
+        self.enter_result = enter_result
+
+    def __enter__(self):
+        return self.enter_result
+
+    def __exit__(self, *excinfo):
+        return False
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"contextlib",
+    kind: NativeModuleKind::Create,
+    functions: &[],
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    assert!(execute_module(module, SOURCE), "embedded contextlib module");
+}

--- a/crates/ucharm-runtime/src/modules/mod.rs
+++ b/crates/ucharm-runtime/src/modules/mod.rs
@@ -1,5 +1,6 @@
 mod ansi;
 mod ansi_core;
+mod argparse;
 mod args;
 mod array;
 mod base64;
@@ -9,6 +10,8 @@ mod bytes_methods;
 mod charm;
 mod charm_core;
 mod collections;
+mod configparser;
+mod contextlib;
 mod copy;
 mod csv;
 mod dataclasses;
@@ -50,14 +53,19 @@ mod term;
 mod term_core;
 mod textwrap;
 mod textwrap_core;
+mod tomllib;
 mod typing;
+mod unittest;
+mod urllib_parse;
 mod uuid;
+mod xml_etree;
 mod zipfile;
 
 use crate::native::{NativeModule, register_modules};
 
 const MODULES: &[NativeModule] = &[
     ansi::MODULE,
+    argparse::MODULE,
     struct_module::MODULE,
     array::MODULE,
     args::MODULE,
@@ -67,6 +75,8 @@ const MODULES: &[NativeModule] = &[
     copy::MODULE,
     typing::MODULE,
     collections::MODULE,
+    configparser::MODULE,
+    contextlib::MODULE,
     io::MODULE,
     csv::MODULE,
     dataclasses::MODULE,
@@ -97,8 +107,12 @@ const MODULES: &[NativeModule] = &[
     tempfile::MODULE,
     term::MODULE,
     textwrap::MODULE,
+    tomllib::MODULE,
     subprocess::MODULE,
+    unittest::MODULE,
+    urllib_parse::MODULE,
     uuid::MODULE,
+    xml_etree::MODULE,
     zipfile::MODULE,
 ];
 

--- a/crates/ucharm-runtime/src/modules/tomllib.rs
+++ b/crates/ucharm-runtime/src/modules/tomllib.rs
@@ -1,0 +1,127 @@
+use std::ffi::c_int;
+
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{
+    Arguments, NativeModule, NativeModuleKind, NativeSignature, Value, execute_module,
+    return_string, type_error,
+};
+
+const SIGNATURES: &[NativeSignature] = &[NativeSignature {
+    signature: c"_text(value)",
+    callback: text,
+}];
+
+const SOURCE: &str = r#"
+def _strip_comment(line):
+    quote = None
+    escaped = False
+    result = ''
+    for char in line:
+        if escaped:
+            result += char
+            escaped = False
+        elif char == '\\' and quote == '"':
+            result += char
+            escaped = True
+        elif char == "'" or char == '"':
+            if quote is None:
+                quote = char
+            elif quote == char:
+                quote = None
+            result += char
+        elif char == '#' and quote is None:
+            return result
+        else:
+            result += char
+    return result
+
+def _value(raw):
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] in "'\"" and raw[-1] == raw[0]:
+        return raw[1:-1]
+    if raw == 'true':
+        return True
+    if raw == 'false':
+        return False
+    if raw.startswith('[') and raw.endswith(']'):
+        inside = raw[1:-1].strip()
+        if not inside:
+            return []
+        return [_value(item) for item in inside.split(',')]
+    if '.' in raw:
+        return float(raw)
+    return int(raw)
+
+def loads(data):
+    data = _text(data)
+    root = {}
+    current = root
+    for raw_line in data.split('\n'):
+        line = _strip_comment(raw_line).strip()
+        if not line:
+            continue
+        if line.startswith('[') and line.endswith(']'):
+            current = root
+            for part in line[1:-1].split('.'):
+                key = part.strip()
+                if key not in current:
+                    current[key] = {}
+                current = current[key]
+            continue
+        index = line.index('=')
+        key = line[:index].strip()
+        raw = line[index + 1:]
+        target = current
+        parts = key.split('.')
+        for part in parts[:-1]:
+            part = part.strip()
+            if part not in target:
+                target[part] = {}
+            target = target[part]
+        target[parts[-1].strip()] = _value(raw)
+    return root
+
+def load(file):
+    if hasattr(file, 'read'):
+        return loads(file.read())
+    stream = open(file, 'rb')
+    data = stream.read()
+    stream.close()
+    return loads(data)
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"tomllib",
+    kind: NativeModuleKind::Create,
+    functions: &[],
+    signatures: SIGNATURES,
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, SOURCE) {
+        // SAFETY: module initialization failed with a live PocketPy exception.
+        unsafe { ffi::py_printexc() };
+        panic!("embedded tomllib module");
+    }
+}
+
+unsafe extern "C" fn text(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(value) = arguments.get(0) else {
+        return type_error(c"expected str or bytes");
+    };
+    if let Some(value) = value.string() {
+        return return_string(&value);
+    }
+    if let Some(value) = value.bytes() {
+        let Ok(value) = String::from_utf8(value) else {
+            return type_error(c"TOML must be UTF-8");
+        };
+        return return_string(&value);
+    }
+    type_error(c"expected str or bytes")
+}

--- a/crates/ucharm-runtime/src/modules/unittest.rs
+++ b/crates/ucharm-runtime/src/modules/unittest.rs
@@ -1,0 +1,205 @@
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{NativeModule, NativeModuleKind, Value, execute_module};
+
+const SOURCE: &str = r#"
+class SkipTest(Exception):
+    pass
+
+class TestResult:
+    def __init__(self):
+        self.testsRun = 0
+        self.failures = []
+        self.errors = []
+        self.skipped = []
+        self.expectedFailures = []
+        self.unexpectedSuccesses = []
+
+    def wasSuccessful(self):
+        return len(self.failures) == 0 and len(self.errors) == 0
+
+class _AssertRaisesContext:
+    def __init__(self, expected):
+        self.expected = expected
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        if len(args) == 0 or args[0] is None:
+            raise AssertionError('did not raise')
+        error = args[0]
+        if isinstance(error, self.expected):
+            return True
+        return False
+
+def _mark_skip(func, active, reason):
+    if active:
+        func.__unittest_skip__ = True
+        func.__unittest_skip_why__ = reason
+    return func
+
+class _SkipDecorator:
+    def __init__(self, active, reason):
+        self.active = active
+        self.reason = reason
+
+    def __call__(self, func):
+        return _mark_skip(func, self.active, self.reason)
+
+def skip(reason):
+    return _SkipDecorator(True, reason)
+
+def skipIf(condition, reason):
+    return _SkipDecorator(condition, reason)
+
+def skipUnless(condition, reason):
+    return _SkipDecorator(not condition, reason)
+
+def expectedFailure(func):
+    func.__unittest_expected_failure__ = True
+    return func
+
+class TestCase:
+    def __init__(self, methodName='runTest'):
+        self._testMethodName = methodName
+
+    def fail(self, msg=None):
+        raise AssertionError(msg or 'test failed')
+
+    def assertTrue(self, expr, msg=None):
+        if not expr: self.fail(msg)
+
+    def assertFalse(self, expr, msg=None):
+        if expr: self.fail(msg)
+
+    def assertEqual(self, first, second, msg=None):
+        if first != second: self.fail(msg)
+
+    def assertNotEqual(self, first, second, msg=None):
+        if first == second: self.fail(msg)
+
+    def assertIs(self, first, second, msg=None):
+        if first is not second: self.fail(msg)
+
+    def assertIsNot(self, first, second, msg=None):
+        if first is second: self.fail(msg)
+
+    def assertIsNone(self, value, msg=None):
+        if value is not None: self.fail(msg)
+
+    def assertIsNotNone(self, value, msg=None):
+        if value is None: self.fail(msg)
+
+    def assertIn(self, member, container, msg=None):
+        if member not in container: self.fail(msg)
+
+    def assertNotIn(self, member, container, msg=None):
+        if member in container: self.fail(msg)
+
+    def assertIsInstance(self, obj, cls, msg=None):
+        if not isinstance(obj, cls): self.fail(msg)
+
+    def assertNotIsInstance(self, obj, cls, msg=None):
+        if isinstance(obj, cls): self.fail(msg)
+
+    def assertGreater(self, first, second, msg=None):
+        if not first > second: self.fail(msg)
+
+    def assertLess(self, first, second, msg=None):
+        if not first < second: self.fail(msg)
+
+    def assertGreaterEqual(self, first, second, msg=None):
+        if not first >= second: self.fail(msg)
+
+    def assertLessEqual(self, first, second, msg=None):
+        if not first <= second: self.fail(msg)
+
+    def assertAlmostEqual(self, first, second, places=7, msg=None):
+        if round(abs(first - second), places) != 0: self.fail(msg)
+
+    def assertRaises(self, expected, *args, **kwargs):
+        if len(args) == 0:
+            return _AssertRaisesContext(expected)
+        callable_obj = args[0]
+        try:
+            callable_obj(*args[1:], **kwargs)
+        except expected:
+            return None
+        raise AssertionError('did not raise')
+
+    def skipTest(self, reason):
+        raise SkipTest(reason)
+
+    def run(self, result=None):
+        if result is None:
+            result = TestResult()
+        result.testsRun += 1
+        method = getattr(self, self._testMethodName)
+        original = getattr(type(self), self._testMethodName)
+        if getattr(original, '__unittest_skip__', False):
+            result.skipped.append(getattr(original, '__unittest_skip_why__', 'skipped'))
+            return result
+        expected = getattr(original, '__unittest_expected_failure__', False)
+        if hasattr(self, 'setUp'):
+            self.setUp()
+        succeeded = False
+        try:
+            method()
+            succeeded = True
+        except SkipTest:
+            result.skipped.append('skipped')
+        except AssertionError:
+            if expected:
+                result.expectedFailures.append('expectedFailure')
+            else:
+                result.failures.append('failure')
+        except Exception:
+            result.errors.append('error')
+        if succeeded and expected:
+            result.unexpectedSuccesses.append('unexpectedSuccess')
+        if hasattr(self, 'tearDown'):
+            self.tearDown()
+        return result
+
+class TestSuite:
+    def __init__(self, tests=None):
+        self._tests = [] if tests is None else list(tests)
+
+    def addTest(self, test):
+        self._tests.append(test)
+
+    def countTestCases(self):
+        return len(self._tests)
+
+    def run(self, result):
+        for test in self._tests:
+            test.run(result)
+        return result
+
+class TestLoader:
+    def loadTestsFromTestCase(self, test_case_class):
+        suite = TestSuite()
+        for name in dir(test_case_class):
+            if name.startswith('test'):
+                suite.addTest(test_case_class(name))
+        return suite
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"unittest",
+    kind: NativeModuleKind::Create,
+    functions: &[],
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, SOURCE) {
+        // SAFETY: module initialization failed with a live PocketPy exception.
+        unsafe { ffi::py_printexc() };
+        panic!("embedded unittest module");
+    }
+}

--- a/crates/ucharm-runtime/src/modules/urllib_parse.rs
+++ b/crates/ucharm-runtime/src/modules/urllib_parse.rs
@@ -1,0 +1,181 @@
+use std::ffi::c_int;
+
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{
+    Arguments, NativeModule, NativeModuleKind, NativeSignature, Value, execute_module,
+    return_string, type_error,
+};
+
+const SIGNATURES: &[NativeSignature] = &[
+    NativeSignature {
+        signature: c"quote(string, safe='/')",
+        callback: quote,
+    },
+    NativeSignature {
+        signature: c"unquote(string)",
+        callback: unquote,
+    },
+];
+
+const SOURCE: &str = r#"
+class ParseResult:
+    def __init__(self, scheme, netloc, path, params, query, fragment):
+        self.scheme = scheme
+        self.netloc = netloc
+        self.path = path
+        self.params = params
+        self.query = query
+        self.fragment = fragment
+
+    def __getitem__(self, i):
+        return (self.scheme, self.netloc, self.path, self.params, self.query, self.fragment)[i]
+
+    def __iter__(self):
+        return iter((self.scheme, self.netloc, self.path, self.params, self.query, self.fragment))
+
+def urlparse(url, scheme='', allow_fragments=True):
+    fragment = ''
+    if allow_fragments and '#' in url:
+        index = url.index('#')
+        fragment = url[index + 1:]
+        url = url[:index]
+    query = ''
+    if '?' in url:
+        index = url.index('?')
+        query = url[index + 1:]
+        url = url[:index]
+    parsed_scheme = scheme
+    had_slashes = '://' in url
+    if had_slashes:
+        index = url.index('://')
+        parsed_scheme = url[:index]
+        url = url[index + 3:]
+    netloc = ''
+    path = url
+    if had_slashes:
+        if '/' in url:
+            index = url.index('/')
+            netloc = url[:index]
+            path = url[index:]
+        else:
+            netloc = url
+            path = ''
+    return ParseResult(parsed_scheme, netloc, path, '', query, fragment)
+
+def urlunparse(components):
+    if hasattr(components, 'scheme'):
+        scheme, netloc, path = components.scheme, components.netloc, components.path
+        params, query, fragment = components.params, components.query, components.fragment
+    else:
+        scheme, netloc, path, params, query, fragment = components
+    result = (scheme + '://' if scheme else '') + netloc + path
+    if params:
+        result += ';' + params
+    if query:
+        result += '?' + query
+    if fragment:
+        result += '#' + fragment
+    return result
+
+def urljoin(base, url, allow_fragments=True):
+    if '://' in url:
+        return url
+    parsed = urlparse(base)
+    if url.startswith('/'):
+        return urlunparse((parsed.scheme, parsed.netloc, url, '', '', ''))
+    path = parsed.path
+    slash = 0
+    for i in range(len(path)):
+        if path[i] == '/':
+            slash = i
+    return urlunparse((parsed.scheme, parsed.netloc, path[:slash + 1] + url, '', '', ''))
+
+def urlencode(query, doseq=False, safe='', encoding=None, errors=None, quote_via=None):
+    items = list(query.items()) if hasattr(query, 'items') else list(query)
+    parts = []
+    for key, value in items:
+        parts.append(quote(str(key), '').replace('%20', '+') + '=' + quote(str(value), '').replace('%20', '+'))
+    return '&'.join(parts)
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"urllib.parse",
+    kind: NativeModuleKind::Create,
+    functions: &[],
+    signatures: SIGNATURES,
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    assert!(
+        execute_module(module, SOURCE),
+        "embedded urllib.parse module"
+    );
+}
+
+unsafe extern "C" fn quote(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(input) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"quote() requires a string");
+    };
+    let safe = arguments
+        .get(1)
+        .and_then(Value::string)
+        .unwrap_or_else(|| "/".to_owned());
+    let mut output = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        if byte.is_ascii_alphanumeric()
+            || b"_.-~".contains(&byte)
+            || safe.as_bytes().contains(&byte)
+        {
+            output.push(char::from(byte));
+        } else {
+            use std::fmt::Write as _;
+            let _ = write!(output, "%{byte:02X}");
+        }
+    }
+    return_string(&output)
+}
+
+unsafe extern "C" fn unquote(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(input) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"unquote() requires a string");
+    };
+    let bytes = input.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) =
+                (hex_value(bytes[index + 1]), hex_value(bytes[index + 2]))
+        {
+            output.push((high << 4) | low);
+            index += 3;
+            continue;
+        }
+        output.push(if bytes[index] == b'+' {
+            b' '
+        } else {
+            bytes[index]
+        });
+        index += 1;
+    }
+    let Ok(output) = String::from_utf8(output) else {
+        return type_error(c"decoded URL is not UTF-8");
+    };
+    return_string(&output)
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}

--- a/crates/ucharm-runtime/src/modules/xml_etree.rs
+++ b/crates/ucharm-runtime/src/modules/xml_etree.rs
@@ -1,0 +1,112 @@
+use crate::native::{NativeModule, NativeModuleKind, Value, execute_module};
+
+const SOURCE: &str = r#"
+class Element:
+    def __init__(self, tag, attrib=None, **extra):
+        self.tag = tag
+        self.attrib = {} if attrib is None else attrib
+        for key, value in extra.items():
+            self.attrib[key] = value
+        self.text = None
+        self._children = []
+
+    def append(self, element):
+        self._children.append(element)
+
+    def __iter__(self):
+        return iter(self._children)
+
+def SubElement(parent, tag, attrib=None, **extra):
+    child = Element(tag, attrib, **extra)
+    parent.append(child)
+    return child
+
+def _escape(value):
+    return value.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+def _unescape(value):
+    return value.replace('&lt;', '<').replace('&gt;', '>').replace('&quot;', '"').replace('&apos;', "'").replace('&amp;', '&')
+
+def _serialize(element):
+    attributes = ''
+    for key, value in element.attrib.items():
+        attributes += ' ' + key + '=\"' + _escape(str(value)) + '\"'
+    body = '' if element.text is None else _escape(element.text)
+    for child in element._children:
+        body += _serialize(child)
+    return '<' + element.tag + attributes + '>' + body + '</' + element.tag + '>'
+
+def tostring(element, encoding='us-ascii', method='xml'):
+    value = _serialize(element)
+    return value
+
+def _attributes(header):
+    parts = header.split()
+    attributes = {}
+    for part in parts[1:]:
+        if '=' in part:
+            index = part.index('=')
+            key = part[:index]
+            value = part[index + 1:]
+            if len(value) >= 2 and value[0] in "'\"" and value[-1] == value[0]:
+                value = value[1:-1]
+            attributes[key] = _unescape(value)
+    return parts[0], attributes
+
+def _parse_at(source, position):
+    while position < len(source) and source[position] in ' \t\r\n':
+        position += 1
+    if position >= len(source) or source[position] != '<':
+        raise ValueError('expected element')
+    close = source.index('>', position)
+    header = source[position + 1:close].strip()
+    self_closing = header.endswith('/')
+    if self_closing:
+        header = header[:-1].strip()
+    tag, attributes = _attributes(header)
+    element = Element(tag, attributes)
+    position = close + 1
+    if self_closing:
+        return element, position
+    text = ''
+    while position < len(source):
+        if source[position:].startswith('</' + tag):
+            end = source.index('>', position)
+            if text:
+                element.text = _unescape(text)
+            return element, end + 1
+        if source[position] == '<':
+            child, position = _parse_at(source, position)
+            element.append(child)
+        else:
+            start = position
+            while position < len(source) and source[position] != '<':
+                position += 1
+            text += source[start:position]
+    raise ValueError('unclosed element')
+
+def fromstring(text, parser=None):
+    if not isinstance(text, str):
+        text = text.decode()
+    element, position = _parse_at(text, 0)
+    return element
+
+XML = fromstring
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"xml.etree.ElementTree",
+    kind: NativeModuleKind::Create,
+    functions: &[],
+    signatures: &[],
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    assert!(
+        execute_module(module, SOURCE),
+        "embedded ElementTree module"
+    );
+}

--- a/crates/ucharm-runtime/tests/tooling_format_wave.rs
+++ b/crates/ucharm-runtime/tests/tooling_format_wave.rs
@@ -1,0 +1,174 @@
+use std::process::{Command, Output};
+
+#[test]
+fn passes_all_tooling_format_wave_compatibility_fixtures() {
+    for (module, source, summary) in [
+        (
+            "argparse",
+            include_str!("../../../tests/cpython/test_argparse.py"),
+            "Results: 26 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "configparser",
+            include_str!("../../../tests/cpython/test_configparser.py"),
+            "Results: 26 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "contextlib",
+            include_str!("../../../tests/cpython/test_contextlib.py"),
+            "Results: 10 passed, 0 failed, 4 skipped",
+        ),
+        (
+            "unittest",
+            include_str!("../../../tests/cpython/test_unittest.py"),
+            "Results: 40 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "urllib.parse",
+            include_str!("../../../tests/cpython/test_urllib_parse.py"),
+            "Results: 24 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "tomllib",
+            include_str!("../../../tests/cpython/test_tomllib.py"),
+            "Results: 4 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "xml.etree.ElementTree",
+            include_str!("../../../tests/cpython/test_xml_etree_elementtree.py"),
+            "Results: 12 passed, 0 failed, 0 skipped",
+        ),
+    ] {
+        let output = run(source);
+        assert!(
+            output.status.success(),
+            "{module} fixture failed:\n{}",
+            diagnostic(&output)
+        );
+        assert!(
+            text(&output.stdout).contains(summary),
+            "{module} summary missing:\n{}",
+            diagnostic(&output)
+        );
+        assert_eq!(text(&output.stderr), "", "{module}");
+    }
+}
+
+#[test]
+fn matches_cpython_for_deterministic_tooling_and_format_operations() {
+    let source = concat!(
+        "import argparse, configparser, tomllib\n",
+        "from urllib.parse import quote, unquote, urljoin, urlparse\n",
+        "from xml.etree.ElementTree import Element, SubElement, tostring\n",
+        "parser = argparse.ArgumentParser(description='demo')\n",
+        "parser.add_argument('--count', type=int, default=2)\n",
+        "parser.add_argument('name')\n",
+        "args = parser.parse_args(['--count', '3', 'alice'])\n",
+        "print(args.name, args.count, parser.description)\n",
+        "config = configparser.ConfigParser()\n",
+        "config.read_string('[core]\\ncount = 3\\nenabled = yes\\n')\n",
+        "print(config.sections(), config.getint('core', 'count'), config.getboolean('core', 'enabled'))\n",
+        "url = 'https://example.com/a b?q=one#two'\n",
+        "parsed = urlparse(url)\n",
+        "print(parsed.scheme, parsed.netloc, parsed.path, parsed.query, parsed.fragment)\n",
+        "print(unquote(quote('μ charm')), urljoin('https://example.com/a/', 'b'))\n",
+        "document = tomllib.loads(\"name='ucharm'\\n[tool]\\ncount=3\\n\")\n",
+        "print(document['name'], document['tool']['count'])\n",
+        "root = Element('root', {'kind': 'demo'})\n",
+        "SubElement(root, 'child').text = 'a < b'\n",
+        "print(tostring(root, 'unicode'))\n",
+    );
+    let rust = run(source);
+    assert!(rust.status.success(), "{}", diagnostic(&rust));
+    let cpython = Command::new("python3")
+        .args(["-c", source])
+        .output()
+        .expect("run CPython differential oracle");
+    assert!(cpython.status.success(), "{}", diagnostic(&cpython));
+    assert_eq!(rust.stdout, cpython.stdout);
+    assert_eq!(text(&rust.stderr), "");
+}
+
+#[test]
+fn preserves_state_and_nested_formats_under_stress() {
+    let output = run(concat!(
+        "import argparse, configparser, contextlib, tomllib, unittest\n",
+        "from urllib.parse import quote, unquote\n",
+        "from xml.etree.ElementTree import fromstring, tostring\n",
+        "closed = []\n",
+        "@contextlib.contextmanager\n",
+        "def managed(value):\n",
+        "    yield value\n",
+        "    closed.append(value)\n",
+        "case = unittest.TestCase()\n",
+        "for i in range(250):\n",
+        "    parser = argparse.ArgumentParser()\n",
+        "    parser.add_argument('--value', type=int, required=True)\n",
+        "    parser.add_argument('items', nargs='+')\n",
+        "    args = parser.parse_args(['--value', str(i), 'a', 'b'])\n",
+        "    assert args.value == i and args.items == ['a', 'b']\n",
+        "    config = configparser.ConfigParser()\n",
+        "    config.read_string('[item]\\nvalue=' + str(i) + '\\nenabled=true\\n')\n",
+        "    assert config.getint('item', 'value') == i and config.getboolean('item', 'enabled')\n",
+        "    encoded = quote('μ value ' + str(i))\n",
+        "    assert unquote(encoded) == 'μ value ' + str(i)\n",
+        "    assert unquote('%Aμ') == '%Aμ'\n",
+        "    data = tomllib.loads(\"title='a#b' # comment\\n[outer.inner]\\nvalue=\" + str(i))\n",
+        "    assert data['title'] == 'a#b' and data['outer']['inner']['value'] == i\n",
+        "    xml = fromstring('<root id=\"' + str(i) + '\"><child>a &lt; b</child></root>')\n",
+        "    assert xml.attrib['id'] == str(i) and list(xml)[0].text == 'a < b'\n",
+        "    assert 'a &lt; b' in tostring(xml, 'unicode')\n",
+        "    with managed(i) as value:\n",
+        "        case.assertEqual(value, i)\n",
+        "assert len(closed) == 250 and closed[-1] == 249\n",
+    ));
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(text(&output.stderr), "");
+}
+
+#[test]
+fn rejects_invalid_arguments_formats_and_assertions() {
+    let output = run(concat!(
+        "import argparse, configparser, tomllib, unittest\n",
+        "from xml.etree.ElementTree import fromstring\n",
+        "def must_fail(expected, operation):\n",
+        "    try:\n",
+        "        operation()\n",
+        "    except expected:\n",
+        "        return\n",
+        "    raise AssertionError('operation unexpectedly succeeded')\n",
+        "parser = argparse.ArgumentParser()\n",
+        "parser.add_argument('--mode', choices=['a', 'b'], required=True)\n",
+        "must_fail(SystemExit, lambda: parser.parse_args([]))\n",
+        "must_fail(SystemExit, lambda: parser.parse_args(['--mode', 'c']))\n",
+        "must_fail(SystemExit, lambda: parser.parse_args(['--mode', 'a', 'extra']))\n",
+        "must_fail(ValueError, lambda: configparser.ConfigParser().read_string('missing header = true'))\n",
+        "must_fail(Exception, lambda: tomllib.loads('value=nope'))\n",
+        "must_fail(Exception, lambda: fromstring('<root><child></root>'))\n",
+        "case = unittest.TestCase()\n",
+        "must_fail(AssertionError, lambda: case.assertEqual(1, 2))\n",
+        "case.assertRaises(ValueError, lambda: int('not-an-int'))\n",
+    ));
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(text(&output.stderr), "");
+}
+
+fn run(source: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pocketpy-ucharm-rs"))
+        .args(["-c", source])
+        .output()
+        .expect("run Rust PocketPy runtime")
+}
+
+fn text(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn diagnostic(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        text(&output.stdout),
+        text(&output.stderr)
+    )
+}

--- a/tests/compat_report_pocketpy.md
+++ b/tests/compat_report_pocketpy.md
@@ -1,14 +1,14 @@
 # μcharm Compatibility Report
 
-Generated: 2026-08-04 19:16:48
+Generated: 2026-08-04 20:02:36
 
 ## Summary
 
 ### Targeted Modules
 
-- **Tests passing**: 1,437/1,668 (86.2%)
-- **Modules at 100%**: 39/52
-- **Modules partial**: 5/52
+- **Tests passing**: 1,574/1,668 (94.4%)
+- **Modules at 100%**: 46/52
+- **Modules partial**: 3/52
 - **No baseline (host CPython)**: 1/52
 
 ### CPython Stdlib Coverage
@@ -20,11 +20,14 @@ Generated: 2026-08-04 19:16:48
 
 | Module | Category | CPython | μcharm | Parity | Notes |
 |--------|----------|---------|--------|--------|-------|
+| argparse | stdlib | 26/26 | 26/26 | 100% | ✅ Full |
 | array | stdlib | 69/69 | 69/69 | 100% | ✅ Full |
 | base64 | stdlib | 18/18 | 18/18 | 100% | ✅ Full |
 | binascii | stdlib | 55/55 | 55/55 | 100% | ✅ Full |
 | bisect | stdlib | 58/58 | 58/58 | 100% | ✅ Full |
 | collections | stdlib | 49/49 | 49/49 | 100% | ✅ Full |
+| configparser | stdlib | 26/26 | 26/26 | 100% | ✅ Full |
+| contextlib | stdlib | 10/10 | 10/10 | 100% | ✅ Full |
 | copy | stdlib | 33/33 | 33/33 | 100% | ✅ Full |
 | csv | stdlib | 24/24 | 24/24 | 100% | ✅ Full |
 | dataclasses | stdlib | 8/8 | 8/8 | 100% | ✅ Full |
@@ -57,51 +60,29 @@ Generated: 2026-08-04 19:16:48
 | tempfile | stdlib | 9/9 | 9/9 | 100% | ✅ Full |
 | textwrap | stdlib | 24/24 | 24/24 | 100% | ✅ Full |
 | toml | stdlib | - | - | - | ✅ Full |
+| tomllib | stdlib | 0/1 | 1/1 | 100% | ✅ Full |
 | typing | stdlib | 43/43 | 43/43 | 100% | ✅ Full |
+| unittest | stdlib | 40/40 | 40/40 | 100% | ✅ Full |
+| urllib_parse | stdlib | 24/24 | 24/24 | 100% | ✅ Full |
 | uuid | stdlib | 18/18 | 18/18 | 100% | ✅ Full |
+| xml.etree.ElementTree | stdlib | 12/12 | 12/12 | 100% | ✅ Full |
 | zipfile | stdlib | 7/7 | 7/7 | 100% | ✅ Full |
 | math | stdlib | 82/82 | 73/82 | 89% | 9 skipped |
 | time | stdlib | 42/42 | 22/42 | 52% | 6 skipped |
 | sys | stdlib | 58/58 | 3/58 | 5% | 1 failing |
-| urllib_parse | stdlib | 24/24 | 1/24 | 4% | 1 skipped |
-| configparser | stdlib | 26/26 | 1/26 | 4% | 1 skipped |
-| argparse | stdlib | 26/26 | 0/26 | 0% | 1 skipped |
-| contextlib | stdlib | 10/10 | 0/10 | 0% | 1 failing |
 | http.client | stdlib | 8/8 | 0/8 | 0% |  |
 | sqlite3 | stdlib | 2/2 | 0/2 | 0% |  |
-| tomllib | stdlib | 0/1 | 0/1 | 0% |  |
-| unittest | stdlib | 40/40 | 0/40 | 0% | 1 skipped |
-| xml.etree.ElementTree | stdlib | 12/12 | 0/12 | 0% |  |
 
 ## Failed Tests
-
-### argparse
-
-- `error: Python execution failed
-`
-
-### contextlib
-
-- `error: Python execution failed
-`
 
 ### sys
 
 - `FAIL: version_info exists`
 
-### unittest
-
-- `error: Python execution failed
-`
-
 
 ## Skipped Tests
 
 These tests require features not available in pocketpy-ucharm:
-
-### argparse
-
-- 1 tests skipped
 
 ### bisect
 
@@ -111,9 +92,9 @@ These tests require features not available in pocketpy-ucharm:
 
 - 4 tests skipped
 
-### configparser
+### contextlib
 
-- 1 tests skipped
+- 4 tests skipped
 
 ### enum
 
@@ -131,15 +112,7 @@ These tests require features not available in pocketpy-ucharm:
 
 - 6 tests skipped
 
-### urllib_parse
-
-- 1 tests skipped
-
 ### toml
-
-- 1 tests skipped
-
-### unittest
 
 - 1 tests skipped
 


### PR DESCRIPTION
## What changed

- ported `argparse`, `configparser`, `contextlib`, `unittest`, `urllib.parse`, `tomllib`, and `xml.etree.ElementTree` into the Rust-hosted PocketPy runtime
- kept parser, test-runner, context-manager, URL, TOML, and XML state owned by PocketPy, with narrow Rust callbacks for UTF-8-safe URL/TOML byte conversion
- added wave-level fixture, CPython differential, 250-round stress, malformed-input, Unicode, and state-isolation coverage
- added a four-target release smoke and refreshed the compatibility report and migration roadmap

## Why

These modules form the remaining low-risk tooling and format cluster. Moving them together avoids seven small review/CI cycles while keeping network and database boundaries isolated for later measured decisions.

## Impact

- compatibility rises from **1,437/1,668 (86.2%)** to **1,574/1,668 (94.4%)**
- **+137 conservative passing checks / +8.2 percentage points**
- module state moves from **39 full / 5 partial / 7 failing-or-unavailable** to **46 full / 3 partial / 2 failing / 1 unavailable**
- all seven fixtures pass **142/142 raw checks**
- ARM64 release runtime: **986,624 bytes**, **5.222 ms median / 5.641 ms p95**
- x86_64 release runtime: **1,068,424 bytes**, **12.347 ms median / 14.457 ms p95** under Rosetta

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo audit` (26 dependencies, no vulnerabilities)
- full compatibility report
- optimized ARM64 and x86_64 builds, all seven fixtures, and exact CI smoke

