### PR TITLE
Port the Rust core runtime wave

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,6 +98,11 @@ jobs:
         run: >-
           target/${{ matrix.target }}/release/pocketpy-ucharm-rs
           -c 'import argparse, configparser, contextlib, tomllib, unittest; from urllib.parse import quote, unquote; from xml.etree.ElementTree import fromstring, tostring; parser = argparse.ArgumentParser(); parser.add_argument("--count", type=int, required=True); assert parser.parse_args(["--count", "3"]).count == 3; config = configparser.ConfigParser(); config.read_string("[core]\nenabled=yes\n"); assert config.getboolean("core", "enabled"); assert unquote(quote("μ charm")) == "μ charm"; assert tomllib.loads("name=\"ucharm\"")["name"] == "ucharm"; xml = fromstring("<root><child>a &lt; b</child></root>"); assert "a &lt; b" in tostring(xml, "unicode"); case = unittest.TestCase(); case.assertEqual(2 + 2, 4); assert contextlib.nullcontext("ok").__enter__() == "ok"'
+      - name: Smoke-test Rust core-runtime wave
+        shell: bash
+        run: >-
+          target/${{ matrix.target }}/release/pocketpy-ucharm-rs
+          -c 'import math, sys, time; assert math.frexp(8.0) == (0.5, 4); assert math.ldexp(0.5, 4) == 8.0; epoch = time.gmtime(0); assert epoch[:3] == (1970, 1, 1); assert time.strftime("%Y-%m-%d", epoch) == "1970-01-01"; parsed = time.strptime("2024-02-29", "%Y-%m-%d"); assert parsed[:3] == (2024, 2, 29); assert time.monotonic() >= 0; assert sys.version_info[0] == 3; assert sys.modules["sys"] is sys; assert sys.intern("ucharm") is sys.intern("ucharm"); assert "ABC123".isalnum() and "123".isdigit()'
       - name: Smoke-test Rust CLI
         shell: bash
         run: target/${{ matrix.target }}/release/ucharm-rs --version | grep -q "μcharm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +73,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,10 +140,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "md-5"
@@ -129,10 +209,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "sha1"
@@ -167,6 +300,48 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "typenum"
@@ -206,6 +381,7 @@ name = "ucharm-runtime"
 version = "0.5.0"
 dependencies = [
  "flate2",
+ "jiff",
  "libc",
  "md-5",
  "regex-lite",
@@ -213,3 +389,15 @@ dependencies = [
  "sha2",
  "ucharm-pocketpy-sys",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,9 +5,9 @@ This is the single source of truth for priorities and next steps.
 ## Snapshot
 
 - Goal: build beautiful CLI apps with Python syntax, shipped as tiny, fast binaries.
-- Runtime: PocketPy; the Rust host, loader, CLI, and 46 fully compatible stdlib targets are implemented while the remaining native modules migrate from Zig.
+- Runtime: PocketPy; the Rust host, loader, CLI, and 49 fully compatible stdlib targets are implemented while the remaining native modules migrate from Zig.
 - Language decision: Rust is the target implementation language. See `RUST_MIGRATION.md` for gates and sequencing.
-- Compatibility status: the Rust migration runtime passes 1,574/1,668 checks (94.4%), with 46/52 targeted modules at 100% parity. Refresh with `python3 tests/compat_runner.py --runtime target/debug/pocketpy-ucharm-rs --report`.
+- Compatibility status: the Rust migration runtime passes 1,658/1,668 checks (99.4%), with 49/52 targeted modules at 100% parity and no partial modules. Refresh with `python3 tests/compat_runner.py --runtime target/debug/pocketpy-ucharm-rs --report`.
 - PocketPy vendor patches are tracked under `pocketpy/patches/` and verified via `python3 scripts/verify-pocketpy-patches.py --check-upstream`.
 
 ## Current State (from the repo)

--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ ucharm/
 
 Current compatibility summary (from `tests/compat_report_pocketpy.md`):
 
-- Rust migration runtime: 1,574/1,668 tests passing (94.4%)
-- 52 targeted modules, with 46 at 100% parity on the Rust host
-- 5.222ms median native ARM64 startup and a 986,624-byte stripped runtime in
+- Rust migration runtime: 1,658/1,668 tests passing (99.4%)
+- 52 targeted modules, with 49 at 100% parity and no partial modules on the Rust host
+- 5.359ms median native ARM64 startup and a 1,003,984-byte stripped runtime in
   the latest 400-run migration sample
 
 ## Showcase

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Current compatibility summary (from `tests/compat_report_pocketpy.md`):
 
 - Rust migration runtime: 1,658/1,668 tests passing (99.4%)
 - 52 targeted modules, with 49 at 100% parity and no partial modules on the Rust host
-- 5.359ms median native ARM64 startup and a 1,003,984-byte stripped runtime in
+- 5.318ms median native ARM64 startup and a 1,186,720-byte stripped runtime in
   the latest 400-run migration sample
 
 ## Showcase

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -198,7 +198,8 @@ status, stdout, and stderr.
   `tempfile`, and `shutil`; and the process/regex/observability wave: `re`,
   `logging`, `signal`, and `subprocess`; plus the tooling/format wave:
   `argparse`, `configparser`, `contextlib`, `unittest`, `urllib.parse`,
-  `tomllib`, and `xml.etree.ElementTree`.
+  `tomllib`, and `xml.etree.ElementTree`; and the core-runtime wave:
+  `math`, `time`, `sys`, and the legacy ASCII string classifiers.
   The shared boundary copies PocketPy bytes into owned Rust buffers before
   allocation, roots
   exact-size byte and float results, supports equality and ordered comparison,
@@ -259,16 +260,24 @@ status, stdout, and stderr.
   conversion. Its seven fixtures pass 142/142 raw checks and add 137 checks to
   the conservative report, backed by CPython differential output, 250-round
   nested parser/serializer stress, malformed-input coverage, Unicode URL
-  round-trips, and four-target release smoke. The full Rust result is now
-  1,574/1,668 (94.4%), up from the original 456/1,668, with 46 of 52 targeted
-  modules at full parity.
+  round-trips, and four-target release smoke. The core-runtime wave extends
+  PocketPy's existing math, clock, argument, and recursion primitives rather
+  than replacing them. Rust adds the missing hyperbolic/frexp/ldexp math
+  surface; libc-backed local/UTC calendar conversion and formatting; standard
+  sys metadata, module registry, interning, and streams; and the Zig runtime's
+  ASCII string classifiers. Its three fixtures pass 182/182 raw checks plus
+  1,000-round math/interning stress, CPython differential output, calendar
+  round-trips, domain/type failures, exact stream bytes, and dual-architecture
+  release smoke. The full Rust result is now 1,658/1,668 (99.4%), up from the
+  original 456/1,668, with 49 of 52 targeted modules at full parity and no
+  partial modules.
   Related low-risk modules now move as validated waves; standalone PRs are
   reserved for boundaries whose ownership or binary-format risk warrants them.
-- The current stripped macOS runtime is 986,624 bytes on ARM64 and 1,068,424
+- The current stripped macOS runtime is 1,003,984 bytes on ARM64 and 1,081,496
   bytes on x86_64, versus 2,313,264 bytes for the legacy Zig ARM64 runtime.
-  On the latest 400-run warm-start sample, native Rust measured 5.222 ms median
-  and 5.641 ms p95; x86_64 Rust under Rosetta measured 12.347 ms median and
-  14.457 ms p95. The native ARM64 host remains below the 10 ms gate; native
+  On the latest 400-run warm-start sample, native Rust measured 5.359 ms median
+  and 5.912 ms p95; x86_64 Rust under Rosetta measured 12.405 ms median and
+  13.653 ms p95. The native ARM64 host remains below the 10 ms gate; native
   Intel CI remains the authoritative x86_64 execution environment.
 
 ### Phase 0 — Freeze and baseline

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -263,22 +263,27 @@ status, stdout, and stderr.
   round-trips, and four-target release smoke. The core-runtime wave extends
   PocketPy's existing math, clock, argument, and recursion primitives rather
   than replacing them. Rust adds the missing hyperbolic/frexp/ldexp math
-  surface; libc-backed local/UTC calendar conversion and formatting; standard
+  surface; feature-minimal Jiff-backed local/UTC calendar conversion,
+  formatting, parsing, and system/POSIX time-zone resolution without direct
+  libc calendar calls or a bundled time-zone database; standard
   sys metadata, module registry, interning, and streams; and the Zig runtime's
   ASCII string classifiers. Its three fixtures pass 182/182 raw checks plus
-  1,000-round math/interning stress, CPython differential output, calendar
-  round-trips, domain/type failures, exact stream bytes, and dual-architecture
-  release smoke. The full Rust result is now 1,658/1,668 (99.4%), up from the
+  1,000-round math/interning stress, CPython differential output, IANA and
+  POSIX `TZ` DST regression coverage, calendar round-trips, domain/type
+  failures, exact stream bytes, and dual-architecture release smoke. The full
+  Rust result is now 1,658/1,668 (99.4%), up from the
   original 456/1,668, with 49 of 52 targeted modules at full parity and no
   partial modules.
   Related low-risk modules now move as validated waves; standalone PRs are
   reserved for boundaries whose ownership or binary-format risk warrants them.
-- The current stripped macOS runtime is 1,003,984 bytes on ARM64 and 1,081,496
+- The current stripped macOS runtime is 1,186,720 bytes on ARM64 and 1,291,400
   bytes on x86_64, versus 2,313,264 bytes for the legacy Zig ARM64 runtime.
-  On the latest 400-run warm-start sample, native Rust measured 5.359 ms median
-  and 5.912 ms p95; x86_64 Rust under Rosetta measured 12.405 ms median and
-  13.653 ms p95. The native ARM64 host remains below the 10 ms gate; native
-  Intel CI remains the authoritative x86_64 execution environment.
+  Replacing the new libc time layer with Jiff adds 182,736 ARM64 bytes (18.2%)
+  while remaining below the 2 MB runtime gate. On the latest 400-run warm-start
+  sample, native Rust measured 5.318 ms median and 6.135 ms p95; x86_64 Rust
+  under Rosetta measured 12.333 ms median and 13.408 ms p95. The native ARM64
+  host remains below the 10 ms gate; native Intel CI remains the authoritative
+  x86_64 execution environment.
 
 ### Phase 0 — Freeze and baseline
 

--- a/crates/ucharm-runtime/Cargo.toml
+++ b/crates/ucharm-runtime/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+jiff = { version = "0.2.35", default-features = false, features = ["std", "tz-system", "tzdb-zoneinfo"] }
 libc = "0.2"
 md-5 = { version = "0.11.0", default-features = false }
 regex-lite = "0.1.9"

--- a/crates/ucharm-runtime/src/modules/math.rs
+++ b/crates/ucharm-runtime/src/modules/math.rs
@@ -1,0 +1,189 @@
+use std::ffi::c_int;
+
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{
+    Arguments, NativeModule, NativeModuleKind, NativeSignature, Value, execute_module,
+    global_integer, global_number, global_tuple, return_number, return_value, type_error,
+    value_error,
+};
+
+const SIGNATURES: &[NativeSignature] = &[
+    NativeSignature {
+        signature: c"sinh(x)",
+        callback: sinh,
+    },
+    NativeSignature {
+        signature: c"cosh(x)",
+        callback: cosh,
+    },
+    NativeSignature {
+        signature: c"tanh(x)",
+        callback: tanh,
+    },
+    NativeSignature {
+        signature: c"asinh(x)",
+        callback: asinh,
+    },
+    NativeSignature {
+        signature: c"acosh(x)",
+        callback: acosh,
+    },
+    NativeSignature {
+        signature: c"atanh(x)",
+        callback: atanh,
+    },
+    NativeSignature {
+        signature: c"frexp(x)",
+        callback: frexp,
+    },
+    NativeSignature {
+        signature: c"ldexp(x, i)",
+        callback: ldexp,
+    },
+    NativeSignature {
+        signature: c"expm1(x)",
+        callback: expm1,
+    },
+    NativeSignature {
+        signature: c"log1p(x)",
+        callback: log1p,
+    },
+    NativeSignature {
+        signature: c"hypot(x, y)",
+        callback: hypot,
+    },
+    NativeSignature {
+        signature: c"cbrt(x)",
+        callback: cbrt,
+    },
+];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"math",
+    kind: NativeModuleKind::Extend,
+    functions: &[],
+    signatures: SIGNATURES,
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    assert!(
+        execute_module(module, "tau = 6.283185307179586"),
+        "extend math constants"
+    );
+}
+
+fn unary(argc: c_int, argv: ffi::py_StackRef, operation: impl FnOnce(f64) -> f64) -> bool {
+    // SAFETY: every native callback passes PocketPy's live argument stack.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Ok(value) = arguments.get(0).ok_or(()).and_then(|v| v.cast_number()) else {
+        return type_error(c"expected number");
+    };
+    return_number(operation(value))
+}
+
+unsafe extern "C" fn sinh(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    unary(argc, argv, f64::sinh)
+}
+
+unsafe extern "C" fn cosh(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    unary(argc, argv, f64::cosh)
+}
+
+unsafe extern "C" fn tanh(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    unary(argc, argv, f64::tanh)
+}
+
+unsafe extern "C" fn asinh(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    unary(argc, argv, f64::asinh)
+}
+
+unsafe extern "C" fn acosh(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Ok(value) = arguments.get(0).ok_or(()).and_then(|v| v.cast_number()) else {
+        return type_error(c"expected number");
+    };
+    if value < 1.0 {
+        return value_error(c"math domain error");
+    }
+    return_number(value.acosh())
+}
+
+unsafe extern "C" fn atanh(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Ok(value) = arguments.get(0).ok_or(()).and_then(|v| v.cast_number()) else {
+        return type_error(c"expected number");
+    };
+    if !(-1.0..1.0).contains(&value) {
+        return value_error(c"math domain error");
+    }
+    return_number(value.atanh())
+}
+
+unsafe extern "C" fn frexp(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Ok(value) = arguments.get(0).ok_or(()).and_then(|v| v.cast_number()) else {
+        return type_error(c"expected number");
+    };
+    let (mantissa, exponent) = if value == 0.0 || !value.is_finite() {
+        (value, 0)
+    } else {
+        let exponent = value.abs().log2().floor() as i32 + 1;
+        (value / 2.0_f64.powi(exponent), exponent)
+    };
+    let Some(result) = global_tuple(0, 2) else {
+        return value_error(c"failed to create frexp result");
+    };
+    let mantissa = global_number(1, mantissa);
+    let _ = result.tuple_set(0, mantissa);
+    let exponent = global_integer(1, i64::from(exponent));
+    let _ = result.tuple_set(1, exponent);
+    return_value(result)
+}
+
+unsafe extern "C" fn ldexp(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Ok(value) = arguments.get(0).ok_or(()).and_then(|v| v.cast_number()) else {
+        return type_error(c"expected number");
+    };
+    let Some(exponent) = arguments.get(1).and_then(Value::integer) else {
+        return type_error(c"expected int");
+    };
+    let Ok(exponent) = i32::try_from(exponent) else {
+        return value_error(c"math range error");
+    };
+    return_number(value * 2.0_f64.powi(exponent))
+}
+
+unsafe extern "C" fn expm1(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    unary(argc, argv, f64::exp_m1)
+}
+
+unsafe extern "C" fn log1p(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Ok(value) = arguments.get(0).ok_or(()).and_then(|v| v.cast_number()) else {
+        return type_error(c"expected number");
+    };
+    if value <= -1.0 {
+        return value_error(c"math domain error");
+    }
+    return_number(value.ln_1p())
+}
+
+unsafe extern "C" fn hypot(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Ok(x) = arguments.get(0).ok_or(()).and_then(|v| v.cast_number()) else {
+        return type_error(c"expected number");
+    };
+    let Ok(y) = arguments.get(1).ok_or(()).and_then(|v| v.cast_number()) else {
+        return type_error(c"expected number");
+    };
+    return_number(x.hypot(y))
+}
+
+unsafe extern "C" fn cbrt(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    unary(argc, argv, f64::cbrt)
+}

--- a/crates/ucharm-runtime/src/modules/mod.rs
+++ b/crates/ucharm-runtime/src/modules/mod.rs
@@ -33,6 +33,7 @@ mod io;
 mod itertools;
 mod json;
 mod logging;
+mod math;
 mod operator;
 mod os;
 mod os_path;
@@ -47,12 +48,14 @@ mod statistics_core;
 mod string_methods;
 mod struct_module;
 mod subprocess;
+mod sys;
 mod tarfile;
 mod tempfile;
 mod term;
 mod term_core;
 mod textwrap;
 mod textwrap_core;
+mod time;
 mod tomllib;
 mod typing;
 mod unittest;
@@ -96,6 +99,7 @@ const MODULES: &[NativeModule] = &[
     itertools::MODULE,
     json::MODULE,
     logging::MODULE,
+    math::MODULE,
     operator::MODULE,
     random::MODULE,
     re::MODULE,
@@ -107,8 +111,10 @@ const MODULES: &[NativeModule] = &[
     tempfile::MODULE,
     term::MODULE,
     textwrap::MODULE,
+    time::MODULE,
     tomllib::MODULE,
     subprocess::MODULE,
+    sys::MODULE,
     unittest::MODULE,
     urllib_parse::MODULE,
     uuid::MODULE,

--- a/crates/ucharm-runtime/src/modules/string_methods.rs
+++ b/crates/ucharm-runtime/src/modules/string_methods.rs
@@ -8,6 +8,25 @@ use crate::native::{
 };
 
 pub(super) fn register() {
+    for (name, callback) in [
+        (c"isdigit", isdigit as crate::native::Callback),
+        (c"isalpha", isalpha),
+        (c"isalnum", isalnum),
+        (c"isspace", isspace),
+        (c"islower", islower),
+        (c"istitle", istitle),
+        (c"isdecimal", isdigit),
+        (c"isnumeric", isdigit),
+        (c"isidentifier", isidentifier),
+        (c"isprintable", isprintable),
+        (c"isascii", isascii),
+    ] {
+        bind_type_method(
+            ffi::py_PredefinedType_tp_str as ffi::py_Type,
+            name,
+            callback,
+        );
+    }
     bind_type_method(
         ffi::py_PredefinedType_tp_str as ffi::py_Type,
         c"isupper",
@@ -18,6 +37,118 @@ pub(super) fn register() {
         c"rsplit(self, sep=None, maxsplit=-1)",
         rsplit,
     );
+}
+
+fn return_bool(value: bool) -> bool {
+    let mut roots = RootFrame::new();
+    let result = roots.boolean(value);
+    return_value(result)
+}
+
+fn string_argument(argc: c_int, argv: ffi::py_StackRef) -> Result<String, ()> {
+    // SAFETY: every native callback passes PocketPy's live argument stack.
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    if !arguments.require_arity(1, 1) {
+        return Err(());
+    }
+    arguments.get(0).and_then(Value::string).ok_or_else(|| {
+        let _ = type_error(c"expected string");
+    })
+}
+
+unsafe extern "C" fn isdigit(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Ok(value) = string_argument(argc, argv) else {
+        return false;
+    };
+    return_bool(!value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+unsafe extern "C" fn isalpha(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Ok(value) = string_argument(argc, argv) else {
+        return false;
+    };
+    return_bool(!value.is_empty() && value.bytes().all(|byte| byte.is_ascii_alphabetic()))
+}
+
+unsafe extern "C" fn isalnum(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Ok(value) = string_argument(argc, argv) else {
+        return false;
+    };
+    return_bool(!value.is_empty() && value.bytes().all(|byte| byte.is_ascii_alphanumeric()))
+}
+
+unsafe extern "C" fn isspace(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Ok(value) = string_argument(argc, argv) else {
+        return false;
+    };
+    return_bool(
+        !value.is_empty()
+            && value
+                .bytes()
+                .all(|byte| matches!(byte, b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c)),
+    )
+}
+
+unsafe extern "C" fn islower(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Ok(value) = string_argument(argc, argv) else {
+        return false;
+    };
+    let has_cased = value.bytes().any(|byte| byte.is_ascii_lowercase());
+    return_bool(has_cased && !value.bytes().any(|byte| byte.is_ascii_uppercase()))
+}
+
+unsafe extern "C" fn istitle(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Ok(value) = string_argument(argc, argv) else {
+        return false;
+    };
+    let mut previous_cased = false;
+    let mut has_cased = false;
+    for byte in value.bytes() {
+        if byte.is_ascii_uppercase() {
+            if previous_cased {
+                return return_bool(false);
+            }
+            previous_cased = true;
+            has_cased = true;
+        } else if byte.is_ascii_lowercase() {
+            if !previous_cased {
+                return return_bool(false);
+            }
+            previous_cased = true;
+            has_cased = true;
+        } else {
+            previous_cased = false;
+        }
+    }
+    return_bool(has_cased)
+}
+
+unsafe extern "C" fn isidentifier(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Ok(value) = string_argument(argc, argv) else {
+        return false;
+    };
+    let mut bytes = value.bytes();
+    let Some(first) = bytes.next() else {
+        return return_bool(false);
+    };
+    return_bool(
+        (first.is_ascii_alphabetic() || first == b'_')
+            && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_'),
+    )
+}
+
+unsafe extern "C" fn isprintable(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Ok(value) = string_argument(argc, argv) else {
+        return false;
+    };
+    return_bool(value.bytes().all(|byte| (0x20..=0x7e).contains(&byte)))
+}
+
+unsafe extern "C" fn isascii(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let Ok(value) = string_argument(argc, argv) else {
+        return false;
+    };
+    return_bool(value.is_ascii())
 }
 
 unsafe extern "C" fn isupper(argc: c_int, argv: ffi::py_StackRef) -> bool {

--- a/crates/ucharm-runtime/src/modules/sys.rs
+++ b/crates/ucharm-runtime/src/modules/sys.rs
@@ -1,0 +1,130 @@
+use std::ffi::c_int;
+use std::io::Write;
+
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{
+    Arguments, NativeModule, NativeModuleKind, NativeSignature, RootFrame, Value, execute_module,
+    return_value, type_error,
+};
+
+const SIGNATURES: &[NativeSignature] = &[NativeSignature {
+    signature: c"_stream_write(error, text)",
+    callback: stream_write,
+}];
+
+const SOURCE: &str = r#"
+version_info = (3, 11, 0)
+path = []
+modules = {}
+stdin = None
+maxsize = 9223372036854775807
+executable = ''
+_interned = {}
+
+class _Implementation:
+    def __init__(self):
+        self.name = 'pocketpy'
+
+class _Flags:
+    pass
+
+class _Stream:
+    def __init__(self, error):
+        self.error = error
+
+    def write(self, text):
+        return _stream_write(self.error, text)
+
+    def flush(self):
+        return None
+
+implementation = _Implementation()
+flags = _Flags()
+stdout = _Stream(False)
+stderr = _Stream(True)
+
+def exit(code=None):
+    raise SystemExit(code)
+
+def getsizeof(value):
+    if isinstance(value, str):
+        return max(1, len(value))
+    if isinstance(value, (list, tuple, dict)):
+        return len(value) + 1
+    return 1
+
+def intern(value):
+    if not isinstance(value, str):
+        raise TypeError('expected string')
+    if value in _interned:
+        return _interned[value]
+    _interned[value] = value
+    return value
+"#;
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"sys",
+    kind: NativeModuleKind::Extend,
+    functions: &[],
+    signatures: SIGNATURES,
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: Some(initialize),
+};
+
+fn initialize(module: Value) {
+    if !execute_module(module, SOURCE) {
+        // SAFETY: initialization failed with a live PocketPy exception.
+        unsafe { ffi::py_printexc() };
+        panic!("embedded sys compatibility layer failed");
+    }
+
+    let mut roots = RootFrame::new();
+    let platform = if cfg!(target_os = "macos") {
+        "darwin"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "windows") {
+        "win32"
+    } else {
+        "unix"
+    };
+    if let Some(value) = roots.string(platform) {
+        module.set_attribute(c"platform", value);
+    }
+    if let Some(value) = roots.string(if cfg!(target_endian = "little") {
+        "little"
+    } else {
+        "big"
+    }) {
+        module.set_attribute(c"byteorder", value);
+    }
+
+    let modules = module
+        .attribute(c"modules")
+        .expect("sys.modules created by compatibility source");
+    let key = roots.string("sys").expect("short sys.modules key");
+    assert!(modules.dict_set(key, module), "insert sys into sys.modules");
+}
+
+unsafe extern "C" fn stream_write(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(error) = arguments.get(0).and_then(Value::boolean) else {
+        return type_error(c"stream selector must be bool");
+    };
+    let Some(text) = arguments.get(1).and_then(Value::string) else {
+        return type_error(c"write() argument must be str");
+    };
+    let result = if error {
+        std::io::stderr().write_all(text.as_bytes())
+    } else {
+        std::io::stdout().write_all(text.as_bytes())
+    };
+    if result.is_err() {
+        return type_error(c"failed to write stream");
+    }
+    let mut roots = RootFrame::new();
+    let length = roots.integer(i64::try_from(text.len()).unwrap_or(i64::MAX));
+    return_value(length)
+}

--- a/crates/ucharm-runtime/src/modules/time.rs
+++ b/crates/ucharm-runtime/src/modules/time.rs
@@ -1,7 +1,8 @@
-use std::ffi::{CStr, CString, c_int};
+use std::ffi::{CStr, c_int};
 use std::sync::OnceLock;
 use std::time::Instant;
 
+use jiff::{Timestamp, Zoned, civil::DateTime, fmt::strtime::BrokenDownTime, tz::TimeZone};
 use ucharm_pocketpy_sys as ffi;
 
 use crate::native::{
@@ -47,10 +48,9 @@ pub(super) const MODULE: NativeModule = NativeModule {
     initializer: None,
 };
 
-fn timestamp(value: Option<Value>) -> Result<libc::time_t, &'static CStr> {
+fn timestamp(value: Option<Value>) -> Result<Timestamp, &'static CStr> {
     if value.is_none_or(Value::is_none) {
-        // SAFETY: a null output pointer asks libc to return the current time.
-        return Ok(unsafe { libc::time(std::ptr::null_mut()) });
+        return Ok(Timestamp::now());
     }
     let seconds = value
         .expect("checked Some above")
@@ -59,47 +59,41 @@ fn timestamp(value: Option<Value>) -> Result<libc::time_t, &'static CStr> {
     if !seconds.is_finite() {
         return Err(c"timestamp out of range");
     }
-    Ok(seconds as libc::time_t)
-}
-
-fn converted_time(
-    value: Option<Value>,
-    convert: unsafe extern "C" fn(*const libc::time_t, *mut libc::tm) -> *mut libc::tm,
-) -> bool {
-    let time = match timestamp(value) {
-        Ok(value) => value,
-        Err(message) => return type_error(message),
-    };
-    // SAFETY: libc::tm is a plain C value and zero is a valid initial state.
-    let mut result: libc::tm = unsafe { std::mem::zeroed() };
-    // SAFETY: both pointers are valid for the synchronous libc conversion.
-    if unsafe { convert(&time, &mut result) }.is_null() {
-        return value_error(c"invalid time");
-    }
-    return_tm(&result)
+    Timestamp::from_second(seconds as i64).map_err(|_| c"timestamp out of range")
 }
 
 unsafe extern "C" fn localtime(argc: c_int, argv: ffi::py_StackRef) -> bool {
     let arguments = unsafe { Arguments::from_raw(argc, argv) };
-    converted_time(arguments.get(0), libc::localtime_r)
+    let timestamp = match timestamp(arguments.get(0)) {
+        Ok(value) => value,
+        Err(message) => return type_error(message),
+    };
+    let time_zone = TimeZone::system();
+    let datetime = time_zone.to_datetime(timestamp);
+    let is_dst = i64::from(time_zone.to_offset_info(timestamp).dst().is_dst());
+    return_datetime(datetime, is_dst)
 }
 
 unsafe extern "C" fn gmtime(argc: c_int, argv: ffi::py_StackRef) -> bool {
     let arguments = unsafe { Arguments::from_raw(argc, argv) };
-    converted_time(arguments.get(0), libc::gmtime_r)
+    let timestamp = match timestamp(arguments.get(0)) {
+        Ok(value) => value,
+        Err(message) => return type_error(message),
+    };
+    return_datetime(TimeZone::UTC.to_datetime(timestamp), 0)
 }
 
-fn return_tm(value: &libc::tm) -> bool {
+fn return_datetime(value: DateTime, is_dst: i64) -> bool {
     let values = [
-        i64::from(value.tm_year) + 1900,
-        i64::from(value.tm_mon) + 1,
-        i64::from(value.tm_mday),
-        i64::from(value.tm_hour),
-        i64::from(value.tm_min),
-        i64::from(value.tm_sec),
-        i64::from((value.tm_wday + 6).rem_euclid(7)),
-        i64::from(value.tm_yday) + 1,
-        i64::from(value.tm_isdst),
+        i64::from(value.year()),
+        i64::from(value.month()),
+        i64::from(value.day()),
+        i64::from(value.hour()),
+        i64::from(value.minute()),
+        i64::from(value.second()),
+        i64::from(value.weekday().to_monday_zero_offset()),
+        i64::from(value.day_of_year()),
+        is_dst,
     ];
     let Some(tuple) = global_tuple(0, values.len()) else {
         return runtime_error(c"failed to create struct_time");
@@ -111,7 +105,12 @@ fn return_tm(value: &libc::tm) -> bool {
     return_value(tuple)
 }
 
-fn tm_from_value(value: Value) -> Result<libc::tm, &'static CStr> {
+struct TimeFields {
+    datetime: DateTime,
+    is_dst: i64,
+}
+
+fn time_fields(value: Value) -> Result<TimeFields, &'static CStr> {
     if value.tuple_len().is_none_or(|length| length < 9) {
         return Err(c"time tuple must have at least 9 elements");
     }
@@ -122,19 +121,47 @@ fn tm_from_value(value: Value) -> Result<libc::tm, &'static CStr> {
             .and_then(Value::integer)
             .ok_or(c"time tuple fields must be integers")?;
     }
-    // SAFETY: libc::tm is plain C storage initialized field by field below.
-    let mut result: libc::tm = unsafe { std::mem::zeroed() };
-    result.tm_year = c_int::try_from(fields[0] - 1900).map_err(|_| c"year out of range")?;
-    result.tm_mon = c_int::try_from(fields[1] - 1).map_err(|_| c"month out of range")?;
-    result.tm_mday = c_int::try_from(fields[2]).map_err(|_| c"day out of range")?;
-    result.tm_hour = c_int::try_from(fields[3]).map_err(|_| c"hour out of range")?;
-    result.tm_min = c_int::try_from(fields[4]).map_err(|_| c"minute out of range")?;
-    result.tm_sec = c_int::try_from(fields[5]).map_err(|_| c"second out of range")?;
-    let weekday = c_int::try_from(fields[6]).map_err(|_| c"weekday out of range")?;
-    result.tm_wday = (weekday + 1).rem_euclid(7);
-    result.tm_yday = c_int::try_from(fields[7] - 1).map_err(|_| c"year day out of range")?;
-    result.tm_isdst = c_int::try_from(fields[8]).map_err(|_| c"DST flag out of range")?;
-    Ok(result)
+    let datetime = DateTime::new(
+        i16::try_from(fields[0]).map_err(|_| c"year out of range")?,
+        i8::try_from(fields[1]).map_err(|_| c"month out of range")?,
+        i8::try_from(fields[2]).map_err(|_| c"day out of range")?,
+        i8::try_from(fields[3]).map_err(|_| c"hour out of range")?,
+        i8::try_from(fields[4]).map_err(|_| c"minute out of range")?,
+        i8::try_from(fields[5]).map_err(|_| c"second out of range")?,
+        0,
+    )
+    .map_err(|_| c"calendar field out of range")?;
+    Ok(TimeFields {
+        datetime,
+        is_dst: fields[8],
+    })
+}
+
+fn zoned_is_dst(value: &Zoned) -> bool {
+    value
+        .time_zone()
+        .to_offset_info(value.timestamp())
+        .dst()
+        .is_dst()
+}
+
+fn resolve_local(fields: &TimeFields) -> Result<Zoned, ()> {
+    let time_zone = TimeZone::system();
+    let ambiguous = time_zone.to_ambiguous_zoned(fields.datetime);
+    if fields.is_dst < 0 {
+        return ambiguous.compatible().map_err(|_| ());
+    }
+
+    let desired_dst = fields.is_dst > 0;
+    let earlier = ambiguous.clone().earlier().map_err(|_| ())?;
+    if zoned_is_dst(&earlier) == desired_dst {
+        return Ok(earlier);
+    }
+    let later = ambiguous.clone().later().map_err(|_| ())?;
+    if zoned_is_dst(&later) == desired_dst {
+        return Ok(later);
+    }
+    ambiguous.compatible().map_err(|_| ())
 }
 
 unsafe extern "C" fn mktime(argc: c_int, argv: ffi::py_StackRef) -> bool {
@@ -142,13 +169,15 @@ unsafe extern "C" fn mktime(argc: c_int, argv: ffi::py_StackRef) -> bool {
     let Some(value) = arguments.get(0) else {
         return type_error(c"mktime() requires a time tuple");
     };
-    let mut value = match tm_from_value(value) {
+    let fields = match time_fields(value) {
         Ok(value) => value,
         Err(message) => return type_error(message),
     };
-    // SAFETY: the value is a fully initialized libc::tm.
-    let result = unsafe { libc::mktime(&mut value) };
-    return_number(result as f64)
+    let zoned = match resolve_local(&fields) {
+        Ok(value) => value,
+        Err(()) => return value_error(c"mktime argument out of range"),
+    };
+    return_number(zoned.timestamp().as_second() as f64)
 }
 
 unsafe extern "C" fn strftime(argc: c_int, argv: ffi::py_StackRef) -> bool {
@@ -156,37 +185,20 @@ unsafe extern "C" fn strftime(argc: c_int, argv: ffi::py_StackRef) -> bool {
     let Some(format) = arguments.get(0).and_then(Value::string) else {
         return type_error(c"strftime() format must be a string");
     };
-    let format = match CString::new(format) {
-        Ok(value) => value,
-        Err(_) => return value_error(c"format contains NUL"),
-    };
-    let time = if arguments.get(1).is_none_or(Value::is_none) {
-        // SAFETY: a null output pointer asks libc to return the current time.
-        let now = unsafe { libc::time(std::ptr::null_mut()) };
-        // SAFETY: libc::tm is plain C storage initialized by localtime_r.
-        let mut value: libc::tm = unsafe { std::mem::zeroed() };
-        // SAFETY: both pointers are valid for the synchronous conversion.
-        if unsafe { libc::localtime_r(&now, &mut value) }.is_null() {
-            return value_error(c"invalid time");
-        }
-        value
+    let zoned = if arguments.get(1).is_none_or(Value::is_none) {
+        Timestamp::now().to_zoned(TimeZone::system())
     } else {
-        match tm_from_value(arguments.get(1).expect("checked Some above")) {
+        let fields = match time_fields(arguments.get(1).expect("checked Some above")) {
             Ok(value) => value,
             Err(message) => return type_error(message),
+        };
+        match resolve_local(&fields) {
+            Ok(value) => value,
+            Err(()) => return value_error(c"invalid time"),
         }
     };
-    let mut buffer = vec![0_i8; 4096];
-    // SAFETY: buffer is writable, format is NUL terminated, and time is initialized.
-    let length =
-        unsafe { libc::strftime(buffer.as_mut_ptr(), buffer.len(), format.as_ptr(), &time) };
-    if length == 0 {
-        return_string_bytes(&[])
-    } else {
-        // SAFETY: libc initialized exactly length bytes in the output buffer.
-        let bytes = unsafe { std::slice::from_raw_parts(buffer.as_ptr().cast::<u8>(), length) };
-        return_string_bytes(bytes)
-    }
+    let output = zoned.strftime(&format).to_string();
+    return_string_bytes(output.as_bytes())
 }
 
 unsafe extern "C" fn strptime(argc: c_int, argv: ffi::py_StackRef) -> bool {
@@ -197,22 +209,42 @@ unsafe extern "C" fn strptime(argc: c_int, argv: ffi::py_StackRef) -> bool {
     let Some(format) = arguments.get(1).and_then(Value::string) else {
         return type_error(c"strptime() format must be a string");
     };
-    let input = match CString::new(input) {
+    let mut parsed = match BrokenDownTime::parse(format.as_bytes(), input.as_bytes()) {
         Ok(value) => value,
-        Err(_) => return value_error(c"input contains NUL"),
+        Err(_) => return value_error(c"time data does not match format"),
     };
-    let format = match CString::new(format) {
-        Ok(value) => value,
-        Err(_) => return value_error(c"format contains NUL"),
-    };
-    // SAFETY: libc::tm is plain C storage initialized by strptime.
-    let mut result: libc::tm = unsafe { std::mem::zeroed() };
-    result.tm_isdst = -1;
-    // SAFETY: both inputs are NUL terminated and result is writable.
-    if unsafe { libc::strptime(input.as_ptr(), format.as_ptr(), &mut result) }.is_null() {
+    if parsed.year().is_none()
+        && parsed.iso_week_year().is_none()
+        && parsed.set_year(Some(1900)).is_err()
+    {
         return value_error(c"time data does not match format");
     }
-    return_tm(&result)
+    let has_alternate_date = parsed.day_of_year().is_some()
+        || parsed.iso_week().is_some()
+        || parsed.sunday_based_week().is_some()
+        || parsed.monday_based_week().is_some();
+    if !has_alternate_date {
+        if parsed.month().is_none() && parsed.set_month(Some(1)).is_err() {
+            return value_error(c"time data does not match format");
+        }
+        if parsed.day().is_none() && parsed.set_day(Some(1)).is_err() {
+            return value_error(c"time data does not match format");
+        }
+    }
+    if parsed.hour().is_none() && parsed.set_hour(Some(0)).is_err() {
+        return value_error(c"time data does not match format");
+    }
+    if parsed.minute().is_none() && parsed.set_minute(Some(0)).is_err() {
+        return value_error(c"time data does not match format");
+    }
+    if parsed.second().is_none() && parsed.set_second(Some(0)).is_err() {
+        return value_error(c"time data does not match format");
+    }
+    let datetime = match parsed.to_datetime() {
+        Ok(value) => value,
+        Err(_) => return value_error(c"time data does not match format"),
+    };
+    return_datetime(datetime, -1)
 }
 
 unsafe extern "C" fn monotonic(_argc: c_int, _argv: ffi::py_StackRef) -> bool {

--- a/crates/ucharm-runtime/src/modules/time.rs
+++ b/crates/ucharm-runtime/src/modules/time.rs
@@ -1,0 +1,222 @@
+use std::ffi::{CStr, CString, c_int};
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use ucharm_pocketpy_sys as ffi;
+
+use crate::native::{
+    Arguments, NativeModule, NativeModuleKind, NativeSignature, Value, global_integer,
+    global_tuple, return_number, return_string_bytes, return_value, runtime_error, type_error,
+    value_error,
+};
+
+const SIGNATURES: &[NativeSignature] = &[
+    NativeSignature {
+        signature: c"localtime(seconds=None)",
+        callback: localtime,
+    },
+    NativeSignature {
+        signature: c"gmtime(seconds=None)",
+        callback: gmtime,
+    },
+    NativeSignature {
+        signature: c"mktime(t)",
+        callback: mktime,
+    },
+    NativeSignature {
+        signature: c"strftime(format, t=None)",
+        callback: strftime,
+    },
+    NativeSignature {
+        signature: c"strptime(string, format)",
+        callback: strptime,
+    },
+    NativeSignature {
+        signature: c"monotonic()",
+        callback: monotonic,
+    },
+];
+
+pub(super) const MODULE: NativeModule = NativeModule {
+    name: c"time",
+    kind: NativeModuleKind::Extend,
+    functions: &[],
+    signatures: SIGNATURES,
+    int_constants: &[],
+    type_aliases: &[],
+    initializer: None,
+};
+
+fn timestamp(value: Option<Value>) -> Result<libc::time_t, &'static CStr> {
+    if value.is_none_or(Value::is_none) {
+        // SAFETY: a null output pointer asks libc to return the current time.
+        return Ok(unsafe { libc::time(std::ptr::null_mut()) });
+    }
+    let seconds = value
+        .expect("checked Some above")
+        .cast_number()
+        .map_err(|()| c"timestamp must be a number")?;
+    if !seconds.is_finite() {
+        return Err(c"timestamp out of range");
+    }
+    Ok(seconds as libc::time_t)
+}
+
+fn converted_time(
+    value: Option<Value>,
+    convert: unsafe extern "C" fn(*const libc::time_t, *mut libc::tm) -> *mut libc::tm,
+) -> bool {
+    let time = match timestamp(value) {
+        Ok(value) => value,
+        Err(message) => return type_error(message),
+    };
+    // SAFETY: libc::tm is a plain C value and zero is a valid initial state.
+    let mut result: libc::tm = unsafe { std::mem::zeroed() };
+    // SAFETY: both pointers are valid for the synchronous libc conversion.
+    if unsafe { convert(&time, &mut result) }.is_null() {
+        return value_error(c"invalid time");
+    }
+    return_tm(&result)
+}
+
+unsafe extern "C" fn localtime(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    converted_time(arguments.get(0), libc::localtime_r)
+}
+
+unsafe extern "C" fn gmtime(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    converted_time(arguments.get(0), libc::gmtime_r)
+}
+
+fn return_tm(value: &libc::tm) -> bool {
+    let values = [
+        i64::from(value.tm_year) + 1900,
+        i64::from(value.tm_mon) + 1,
+        i64::from(value.tm_mday),
+        i64::from(value.tm_hour),
+        i64::from(value.tm_min),
+        i64::from(value.tm_sec),
+        i64::from((value.tm_wday + 6).rem_euclid(7)),
+        i64::from(value.tm_yday) + 1,
+        i64::from(value.tm_isdst),
+    ];
+    let Some(tuple) = global_tuple(0, values.len()) else {
+        return runtime_error(c"failed to create struct_time");
+    };
+    for (index, value) in values.into_iter().enumerate() {
+        let item = global_integer(1, value);
+        let _ = tuple.tuple_set(index, item);
+    }
+    return_value(tuple)
+}
+
+fn tm_from_value(value: Value) -> Result<libc::tm, &'static CStr> {
+    if value.tuple_len().is_none_or(|length| length < 9) {
+        return Err(c"time tuple must have at least 9 elements");
+    }
+    let mut fields = [0_i64; 9];
+    for (index, field) in fields.iter_mut().enumerate() {
+        *field = value
+            .tuple_item(index)
+            .and_then(Value::integer)
+            .ok_or(c"time tuple fields must be integers")?;
+    }
+    // SAFETY: libc::tm is plain C storage initialized field by field below.
+    let mut result: libc::tm = unsafe { std::mem::zeroed() };
+    result.tm_year = c_int::try_from(fields[0] - 1900).map_err(|_| c"year out of range")?;
+    result.tm_mon = c_int::try_from(fields[1] - 1).map_err(|_| c"month out of range")?;
+    result.tm_mday = c_int::try_from(fields[2]).map_err(|_| c"day out of range")?;
+    result.tm_hour = c_int::try_from(fields[3]).map_err(|_| c"hour out of range")?;
+    result.tm_min = c_int::try_from(fields[4]).map_err(|_| c"minute out of range")?;
+    result.tm_sec = c_int::try_from(fields[5]).map_err(|_| c"second out of range")?;
+    let weekday = c_int::try_from(fields[6]).map_err(|_| c"weekday out of range")?;
+    result.tm_wday = (weekday + 1).rem_euclid(7);
+    result.tm_yday = c_int::try_from(fields[7] - 1).map_err(|_| c"year day out of range")?;
+    result.tm_isdst = c_int::try_from(fields[8]).map_err(|_| c"DST flag out of range")?;
+    Ok(result)
+}
+
+unsafe extern "C" fn mktime(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(value) = arguments.get(0) else {
+        return type_error(c"mktime() requires a time tuple");
+    };
+    let mut value = match tm_from_value(value) {
+        Ok(value) => value,
+        Err(message) => return type_error(message),
+    };
+    // SAFETY: the value is a fully initialized libc::tm.
+    let result = unsafe { libc::mktime(&mut value) };
+    return_number(result as f64)
+}
+
+unsafe extern "C" fn strftime(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(format) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"strftime() format must be a string");
+    };
+    let format = match CString::new(format) {
+        Ok(value) => value,
+        Err(_) => return value_error(c"format contains NUL"),
+    };
+    let time = if arguments.get(1).is_none_or(Value::is_none) {
+        // SAFETY: a null output pointer asks libc to return the current time.
+        let now = unsafe { libc::time(std::ptr::null_mut()) };
+        // SAFETY: libc::tm is plain C storage initialized by localtime_r.
+        let mut value: libc::tm = unsafe { std::mem::zeroed() };
+        // SAFETY: both pointers are valid for the synchronous conversion.
+        if unsafe { libc::localtime_r(&now, &mut value) }.is_null() {
+            return value_error(c"invalid time");
+        }
+        value
+    } else {
+        match tm_from_value(arguments.get(1).expect("checked Some above")) {
+            Ok(value) => value,
+            Err(message) => return type_error(message),
+        }
+    };
+    let mut buffer = vec![0_i8; 4096];
+    // SAFETY: buffer is writable, format is NUL terminated, and time is initialized.
+    let length =
+        unsafe { libc::strftime(buffer.as_mut_ptr(), buffer.len(), format.as_ptr(), &time) };
+    if length == 0 {
+        return_string_bytes(&[])
+    } else {
+        // SAFETY: libc initialized exactly length bytes in the output buffer.
+        let bytes = unsafe { std::slice::from_raw_parts(buffer.as_ptr().cast::<u8>(), length) };
+        return_string_bytes(bytes)
+    }
+}
+
+unsafe extern "C" fn strptime(argc: c_int, argv: ffi::py_StackRef) -> bool {
+    let arguments = unsafe { Arguments::from_raw(argc, argv) };
+    let Some(input) = arguments.get(0).and_then(Value::string) else {
+        return type_error(c"strptime() input must be a string");
+    };
+    let Some(format) = arguments.get(1).and_then(Value::string) else {
+        return type_error(c"strptime() format must be a string");
+    };
+    let input = match CString::new(input) {
+        Ok(value) => value,
+        Err(_) => return value_error(c"input contains NUL"),
+    };
+    let format = match CString::new(format) {
+        Ok(value) => value,
+        Err(_) => return value_error(c"format contains NUL"),
+    };
+    // SAFETY: libc::tm is plain C storage initialized by strptime.
+    let mut result: libc::tm = unsafe { std::mem::zeroed() };
+    result.tm_isdst = -1;
+    // SAFETY: both inputs are NUL terminated and result is writable.
+    if unsafe { libc::strptime(input.as_ptr(), format.as_ptr(), &mut result) }.is_null() {
+        return value_error(c"time data does not match format");
+    }
+    return_tm(&result)
+}
+
+unsafe extern "C" fn monotonic(_argc: c_int, _argv: ffi::py_StackRef) -> bool {
+    static START: OnceLock<Instant> = OnceLock::new();
+    let elapsed = START.get_or_init(Instant::now).elapsed().as_secs_f64();
+    return_number(elapsed)
+}

--- a/crates/ucharm-runtime/tests/core_runtime_wave.rs
+++ b/crates/ucharm-runtime/tests/core_runtime_wave.rs
@@ -111,6 +111,32 @@ fn preserves_domain_type_and_calendar_errors() {
 }
 
 #[test]
+fn resolves_iana_and_posix_time_zones_with_dst() {
+    let source = concat!(
+        "import time\n",
+        "assert time.localtime(0) == (1969, 12, 31, 19, 0, 0, 2, 365, 0)\n",
+        "summer = time.localtime(1719792000)\n",
+        "assert summer == (2024, 6, 30, 20, 0, 0, 6, 182, 1)\n",
+        "assert time.mktime((1970, 1, 1, 0, 0, 0, 3, 1, -1)) == 18000.0\n",
+        "assert time.strftime('%z %Z', time.localtime(0)) == '-0500 EST'\n",
+        "assert time.strftime('%z %Z', summer) == '-0400 EDT'\n",
+    );
+    for time_zone in ["America/New_York", "EST5EDT,M3.2.0,M11.1.0"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_pocketpy-ucharm-rs"))
+            .env("TZ", time_zone)
+            .args(["-c", source])
+            .output()
+            .expect("run Rust PocketPy runtime with time zone");
+        assert!(
+            output.status.success(),
+            "{time_zone}: {}",
+            diagnostic(&output)
+        );
+        assert_eq!(text(&output.stderr), "", "{time_zone}");
+    }
+}
+
+#[test]
 fn writes_sys_streams_and_returns_byte_lengths() {
     let output = run(concat!(
         "import sys\n",

--- a/crates/ucharm-runtime/tests/core_runtime_wave.rs
+++ b/crates/ucharm-runtime/tests/core_runtime_wave.rs
@@ -1,0 +1,144 @@
+use std::process::{Command, Output};
+
+#[test]
+fn passes_all_core_runtime_compatibility_fixtures() {
+    for (module, source, summary) in [
+        (
+            "math",
+            include_str!("../../../tests/cpython/test_math.py"),
+            "Results: 82 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "time",
+            include_str!("../../../tests/cpython/test_time.py"),
+            "Results: 42 passed, 0 failed, 0 skipped",
+        ),
+        (
+            "sys",
+            include_str!("../../../tests/cpython/test_sys.py"),
+            "Results: 58 passed, 0 failed, 0 skipped",
+        ),
+    ] {
+        let output = run(source);
+        assert!(
+            output.status.success(),
+            "{module} fixture failed:\n{}",
+            diagnostic(&output)
+        );
+        assert!(
+            text(&output.stdout).contains(summary),
+            "{module} summary missing:\n{}",
+            diagnostic(&output)
+        );
+        assert_eq!(text(&output.stderr), "", "{module}");
+    }
+}
+
+#[test]
+fn matches_cpython_for_deterministic_math_time_and_sys_operations() {
+    let source = concat!(
+        "import math, sys, time\n",
+        "print(round(math.sinh(1), 10), round(math.cosh(1), 10), round(math.tanh(1), 10))\n",
+        "print(math.frexp(8.0), math.ldexp(0.5, 4), round(math.log1p(2), 12))\n",
+        "epoch = time.gmtime(0)\n",
+        "print(tuple(epoch), time.strftime('%Y-%m-%d %H:%M:%S', epoch))\n",
+        "parsed = time.strptime('2024-02-29 12:34:56', '%Y-%m-%d %H:%M:%S')\n",
+        "print(tuple(parsed))\n",
+        "print(sys.version_info[0], sys.byteorder, sys.maxsize > 2**30, sys.implementation.name in ('cpython', 'pocketpy'))\n",
+        "print('ABC123'.isalnum(), '123'.isdigit(), 'Hello World'.istitle())\n",
+    );
+    let rust = run(source);
+    assert!(rust.status.success(), "{}", diagnostic(&rust));
+    let cpython = Command::new("python3")
+        .args(["-c", source])
+        .output()
+        .expect("run CPython differential oracle");
+    assert!(cpython.status.success(), "{}", diagnostic(&cpython));
+    assert_eq!(rust.stdout, cpython.stdout);
+    assert_eq!(text(&rust.stderr), "");
+}
+
+#[test]
+fn preserves_clock_calendar_interning_and_string_state_under_stress() {
+    let output = run(concat!(
+        "import math, sys, time\n",
+        "previous = time.monotonic()\n",
+        "for i in range(1000):\n",
+        "    value = (i - 500) / 100.0\n",
+        "    assert abs(math.ldexp(math.frexp(value)[0], math.frexp(value)[1]) - value) < 1e-12\n",
+        "    assert abs(math.tanh(value)) <= 1.0\n",
+        "    name = sys.intern('item-' + str(i % 25))\n",
+        "    assert name is sys.intern('item-' + str(i % 25))\n",
+        "    assert str(i).isdigit() and ('item_' + str(i)).isidentifier()\n",
+        "current = time.monotonic()\n",
+        "assert current >= previous\n",
+        "for year in range(2000, 2031):\n",
+        "    parsed = time.strptime(str(year) + '-06-15', '%Y-%m-%d')\n",
+        "    assert parsed[0] == year and parsed[1] == 6 and parsed[2] == 15\n",
+        "    assert time.strftime('%Y-%m-%d', parsed) == str(year) + '-06-15'\n",
+        "original = sys.getrecursionlimit()\n",
+        "sys.setrecursionlimit(750)\n",
+        "assert sys.getrecursionlimit() == 750\n",
+        "sys.setrecursionlimit(original)\n",
+    ));
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(text(&output.stderr), "");
+}
+
+#[test]
+fn preserves_domain_type_and_calendar_errors() {
+    let output = run(concat!(
+        "import math, sys, time\n",
+        "def must_fail(expected, operation):\n",
+        "    try:\n",
+        "        operation()\n",
+        "    except expected:\n",
+        "        return\n",
+        "    raise AssertionError('operation unexpectedly succeeded')\n",
+        "must_fail(ValueError, lambda: math.acosh(0.5))\n",
+        "must_fail(ValueError, lambda: math.atanh(1.0))\n",
+        "must_fail(ValueError, lambda: math.log1p(-1.0))\n",
+        "must_fail(TypeError, lambda: math.ldexp(1.0, 1.5))\n",
+        "must_fail(TypeError, lambda: time.mktime((2024, 1)))\n",
+        "must_fail(ValueError, lambda: time.strptime('not-a-date', '%Y-%m-%d'))\n",
+        "must_fail(TypeError, lambda: sys.intern(42))\n",
+        "must_fail(ValueError, lambda: sys.setrecursionlimit(0))\n",
+        "assert ''.isdigit() is False and ''.isprintable() is True\n",
+        "assert 'abc-123'.isascii() and not 'μ'.isascii()\n",
+    ));
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(text(&output.stderr), "");
+}
+
+#[test]
+fn writes_sys_streams_and_returns_byte_lengths() {
+    let output = run(concat!(
+        "import sys\n",
+        "assert sys.stdout.write('output') == 6\n",
+        "assert sys.stderr.write('error') == 5\n",
+        "sys.stdout.flush(); sys.stderr.flush()\n",
+    ));
+    assert!(output.status.success(), "{}", diagnostic(&output));
+    assert_eq!(text(&output.stdout), "output");
+    assert_eq!(text(&output.stderr), "error");
+}
+
+fn run(source: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_pocketpy-ucharm-rs"))
+        .args(["-c", source])
+        .output()
+        .expect("run Rust PocketPy runtime")
+}
+
+fn text(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+fn diagnostic(output: &Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        text(&output.stdout),
+        text(&output.stderr)
+    )
+}

--- a/tests/compat_report_pocketpy.md
+++ b/tests/compat_report_pocketpy.md
@@ -1,14 +1,14 @@
 # μcharm Compatibility Report
 
-Generated: 2026-08-04 20:02:36
+Generated: 2026-08-04 20:16:27
 
 ## Summary
 
 ### Targeted Modules
 
-- **Tests passing**: 1,574/1,668 (94.4%)
-- **Modules at 100%**: 46/52
-- **Modules partial**: 3/52
+- **Tests passing**: 1,658/1,668 (99.4%)
+- **Modules at 100%**: 49/52
+- **Modules partial**: 0/52
 - **No baseline (host CPython)**: 1/52
 
 ### CPython Stdlib Coverage
@@ -45,6 +45,7 @@ Generated: 2026-08-04 20:02:36
 | itertools | stdlib | 33/33 | 33/33 | 100% | ✅ Full |
 | json | stdlib | 70/70 | 70/70 | 100% | ✅ Full |
 | logging | stdlib | 39/39 | 39/39 | 100% | ✅ Full |
+| math | stdlib | 82/82 | 82/82 | 100% | ✅ Full |
 | operator | stdlib | 114/115 | 115/115 | 100% | ✅ Full |
 | os | stdlib | 45/45 | 45/45 | 100% | ✅ Full |
 | pathlib | stdlib | 40/40 | 40/40 | 100% | ✅ Full |
@@ -56,9 +57,11 @@ Generated: 2026-08-04 20:02:36
 | statistics | stdlib | 28/28 | 28/28 | 100% | ✅ Full |
 | struct | stdlib | 68/68 | 68/68 | 100% | ✅ Full |
 | subprocess | stdlib | 19/19 | 19/19 | 100% | ✅ Full |
+| sys | stdlib | 58/58 | 58/58 | 100% | ✅ Full |
 | tarfile | stdlib | 7/7 | 7/7 | 100% | ✅ Full |
 | tempfile | stdlib | 9/9 | 9/9 | 100% | ✅ Full |
 | textwrap | stdlib | 24/24 | 24/24 | 100% | ✅ Full |
+| time | stdlib | 42/42 | 42/42 | 100% | ✅ Full |
 | toml | stdlib | - | - | - | ✅ Full |
 | tomllib | stdlib | 0/1 | 1/1 | 100% | ✅ Full |
 | typing | stdlib | 43/43 | 43/43 | 100% | ✅ Full |
@@ -67,18 +70,8 @@ Generated: 2026-08-04 20:02:36
 | uuid | stdlib | 18/18 | 18/18 | 100% | ✅ Full |
 | xml.etree.ElementTree | stdlib | 12/12 | 12/12 | 100% | ✅ Full |
 | zipfile | stdlib | 7/7 | 7/7 | 100% | ✅ Full |
-| math | stdlib | 82/82 | 73/82 | 89% | 9 skipped |
-| time | stdlib | 42/42 | 22/42 | 52% | 6 skipped |
-| sys | stdlib | 58/58 | 3/58 | 5% | 1 failing |
 | http.client | stdlib | 8/8 | 0/8 | 0% |  |
 | sqlite3 | stdlib | 2/2 | 0/2 | 0% |  |
-
-## Failed Tests
-
-### sys
-
-- `FAIL: version_info exists`
-
 
 ## Skipped Tests
 
@@ -103,14 +96,6 @@ These tests require features not available in pocketpy-ucharm:
 ### json
 
 - 1 tests skipped
-
-### math
-
-- 9 tests skipped
-
-### time
-
-- 6 tests skipped
 
 ### toml
 

--- a/tests/compat_report_pocketpy.md
+++ b/tests/compat_report_pocketpy.md
@@ -1,6 +1,6 @@
 # μcharm Compatibility Report
 
-Generated: 2026-08-04 20:16:27
+Generated: 2026-08-04 20:32:35
 
 ## Summary
 


### PR DESCRIPTION
## What changed

- extend PocketPy's `math` module with the missing hyperbolic, decomposition, precision, and helper functions
- implement `time` calendar conversion, formatting/parsing, system/POSIX time-zone resolution, and monotonic clock support with feature-minimal Jiff instead of direct libc calendar calls
- complete the measured `sys` surface, including metadata, module registration, interning, streams, and process helpers
- add the legacy ASCII string classifiers expected by the Zig runtime
- add differential, stress, error-path, exact-byte, compatibility, and cross-target CI coverage

## Migration impact

- compatibility rises from 1,574/1,668 (94.4%) to 1,658/1,668 (99.4%)
- 49/52 targets now have full parity, with no partially compatible modules remaining
- the three wave fixtures pass 182/182 raw checks
- the only measured gaps left are `http.client` (8 checks) and `sqlite3` (2 checks); `toml` remains unavailable with no measured checks
- Jiff adds 182,736 bytes (18.2%) versus the initial libc implementation, while preserving compatibility and avoiding a bundled time-zone database
- stripped ARM64 runtime: 1,186,720 bytes; native ARM64 startup: 5.318 ms median / 6.135 ms p95 over 400 runs

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo audit`
- full compatibility report: 1,658/1,668 (99.4%)
- IANA and POSIX `TZ` regression coverage for offsets, abbreviations, DST, and `mktime`
- optimized ARM64 and x86_64 builds with exact smoke tests; x86_64 is 1,291,400 bytes and measured 12.333 ms median / 13.408 ms p95 under Rosetta

Tracks #13.
