### PR TITLE
feat: prepare the Rust prerelease bake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
+      - name: Test release versioning
+        run: python3 -m unittest scripts/test_release.py
 
   ffi-sanitizers:
     name: PocketPy FFI sanitizers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,17 +247,19 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body: ${{ steps.changelog.outputs.changelog }}
           files: release/*
           generate_release_notes: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-homebrew:
     name: Update Homebrew Formula
     needs: release
+    if: ${{ !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -398,8 +398,9 @@ Linux ARM64 CLI releases, and enforces genuinely static Linux linkage. The CLI
 embeds only its host component pair and obtains checksum-verified cross-target
 pairs on demand, reducing the ARM64 CLI from 3,723,328 to 2,583,984 bytes. Full
 measurements and the static-link finding are recorded in
-`benchmarks/release_cutover.md`. The native CI bake and prerelease remain before
-the phase exit gate can be marked complete.
+`benchmarks/release_cutover.md`. The native four-target CI bake is green. The
+remaining phase gate is a public prerelease with synchronized Cargo/public
+versions, prerelease metadata, and no Homebrew promotion.
 
 - Switch `justfile`, CI, release workflows, updater scripts, Homebrew formula,
   docs, templates, and contributor instructions to Cargo.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -36,14 +36,20 @@ def get_current_version():
 
 
 def parse_version(version):
-    """Parse version string into components."""
-    parts = version.split(".")
-    return int(parts[0]), int(parts[1]), int(parts[2])
+    """Parse a stable or release-candidate version into components."""
+    version_parts = version.split("-")
+    if len(version_parts) > 2:
+        raise ValueError("version contains more than one prerelease separator")
+    parts = version_parts[0].split(".")
+    if len(parts) != 3:
+        raise ValueError("version must contain major, minor, and patch components")
+    prerelease = version_parts[1] if len(version_parts) == 2 else None
+    return int(parts[0]), int(parts[1]), int(parts[2]), prerelease
 
 
 def bump_version(version, bump_type):
     """Bump version based on type."""
-    major, minor, patch = parse_version(version)
+    major, minor, patch, _ = parse_version(version)
 
     if bump_type == "major":
         return f"{major + 1}.0.0"
@@ -51,6 +57,53 @@ def bump_version(version, bump_type):
         return f"{major}.{minor + 1}.0"
     else:  # patch
         return f"{major}.{minor}.{patch + 1}"
+
+
+def next_release_candidate(version):
+    """Return the next RC, starting a minor RC series from a stable tag."""
+    major, minor, patch, prerelease = parse_version(version)
+    if prerelease is None:
+        return f"{major}.{minor + 1}.0-rc.1"
+
+    prerelease_parts = prerelease.split(".")
+    valid_rc = len(prerelease_parts) == 2
+    valid_rc = valid_rc and prerelease_parts[0] == "rc"
+    valid_rc = valid_rc and prerelease_parts[1].isdigit()
+    if not valid_rc:
+        raise ValueError("only rc.N prerelease versions are supported")
+    return f"{major}.{minor}.{patch}-rc.{int(prerelease_parts[1]) + 1}"
+
+
+def final_version(version):
+    """Remove an RC suffix without changing the release number."""
+    major, minor, patch, _ = parse_version(version)
+    return f"{major}.{minor}.{patch}"
+
+
+def workspace_manifest_with_version(contents, new_version):
+    """Update only the workspace package version in Cargo.toml."""
+    marker = '[workspace.package]\nversion = "'
+    start = contents.find(marker)
+    if start == -1:
+        raise ValueError("Cargo.toml is missing the workspace package version")
+    value_start = start + len(marker)
+    relative_value_end = contents[value_start:].find('"')
+    if relative_value_end == -1:
+        raise ValueError("Cargo.toml has an unterminated workspace package version")
+    value_end = value_start + relative_value_end
+    return contents[:value_start] + new_version + contents[value_end:]
+
+
+def update_version_files(new_version):
+    """Keep the public and Cargo workspace versions synchronized."""
+    with open("VERSION", "w") as version_file:
+        version_file.write(new_version + "\n")
+
+    with open("Cargo.toml", "r") as manifest_file:
+        manifest = manifest_file.read()
+    updated_manifest = workspace_manifest_with_version(manifest, new_version)
+    with open("Cargo.toml", "w") as manifest_file:
+        manifest_file.write(updated_manifest)
 
 
 def has_uncommitted_changes():
@@ -107,13 +160,23 @@ def main():
     next_patch = bump_version(current, "patch")
     next_minor = bump_version(current, "minor")
     next_major = bump_version(current, "major")
+    next_rc = next_release_candidate(current)
+    _, _, _, current_prerelease = parse_version(current)
 
     # Version selection
-    choices = [
-        f"Patch  v{next_patch}  {style('(bug fixes)', fg='gray')}",
-        f"Minor  v{next_minor}  {style('(new features)', fg='gray')}",
-        f"Major  v{next_major}  {style('(breaking changes)', fg='gray')}",
-    ]
+    if current_prerelease is None:
+        choices = [
+            f"Release candidate  v{next_rc}  {style('(public bake)', fg='gray')}",
+            f"Patch  v{next_patch}  {style('(bug fixes)', fg='gray')}",
+            f"Minor  v{next_minor}  {style('(new features)', fg='gray')}",
+            f"Major  v{next_major}  {style('(breaking changes)', fg='gray')}",
+        ]
+    else:
+        stable_version = final_version(current)
+        choices = [
+            f"Release candidate  v{next_rc}  {style('(continue bake)', fg='gray')}",
+            f"Final  v{stable_version}  {style('(promote this RC)', fg='gray')}",
+        ]
 
     choice = select("Select version bump:", choices)
 
@@ -123,7 +186,11 @@ def main():
         sys.exit(0)
 
     # Map choice to version
-    if "Patch" in choice:
+    if "Release candidate" in choice:
+        new_version = next_rc
+    elif "Final" in choice:
+        new_version = final_version(current)
+    elif "Patch" in choice:
         new_version = next_patch
     elif "Minor" in choice:
         new_version = next_minor
@@ -146,25 +213,27 @@ def main():
 
     print()
 
-    # Update VERSION file
-    info("Updating VERSION file...")
+    # Keep VERSION, Cargo.toml, and Cargo.lock synchronized.
+    info("Updating version files...")
     try:
-        with open("VERSION", "w") as f:
-            f.write(new_version + "\n")
-        success("Updated VERSION file")
+        update_version_files(new_version)
+        _, code = run("cargo check --workspace")
+        if code != 0:
+            raise RuntimeError("cargo check failed while refreshing Cargo.lock")
+        success("Updated VERSION, Cargo.toml, and Cargo.lock")
     except Exception as e:
-        error(f"Failed to update VERSION file: {e}")
+        error(f"Failed to update version files: {e}")
+        run("git restore -- VERSION Cargo.toml Cargo.lock")
         sys.exit(1)
 
     # Commit VERSION change
     info("Committing version bump...")
     _, code = run(
-        f'git add VERSION && git commit -m "chore: bump version to {new_version}"'
+        f'git add VERSION Cargo.toml Cargo.lock && git commit -m "chore: bump version to {new_version}"'
     )
     if code != 0:
         error("Failed to commit version bump")
-        # Restore VERSION file
-        run("git checkout VERSION")
+        run("git restore -- VERSION Cargo.toml Cargo.lock")
         sys.exit(1)
     success("Committed version bump")
 

--- a/scripts/test_release.py
+++ b/scripts/test_release.py
@@ -1,0 +1,57 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+RELEASE_SCRIPT = Path(__file__).with_name("release.py")
+fake_ucharm = types.ModuleType("ucharm")
+for function_name in [
+    "box",
+    "confirm",
+    "error",
+    "info",
+    "rule",
+    "select",
+    "style",
+    "success",
+    "warning",
+]:
+    setattr(fake_ucharm, function_name, lambda *args, **kwargs: None)
+sys.modules["ucharm"] = fake_ucharm
+SPEC = importlib.util.spec_from_file_location("ucharm_release", RELEASE_SCRIPT)
+release = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release)
+
+
+class ReleaseVersionTests(unittest.TestCase):
+    def test_parses_stable_and_release_candidate_versions(self):
+        self.assertEqual(release.parse_version("0.5.0"), (0, 5, 0, None))
+        self.assertEqual(
+            release.parse_version("0.6.0-rc.2"),
+            (0, 6, 0, "rc.2"),
+        )
+
+    def test_starts_and_advances_release_candidate_series(self):
+        self.assertEqual(release.next_release_candidate("0.5.0"), "0.6.0-rc.1")
+        self.assertEqual(
+            release.next_release_candidate("0.6.0-rc.1"),
+            "0.6.0-rc.2",
+        )
+        self.assertEqual(release.final_version("0.6.0-rc.2"), "0.6.0")
+
+    def test_rejects_unknown_prerelease_shapes(self):
+        with self.assertRaisesRegex(ValueError, "only rc.N"):
+            release.next_release_candidate("0.6.0-beta.1")
+
+    def test_updates_only_the_workspace_package_version(self):
+        manifest = """[workspace]\nversion = \"unrelated\"\n\n[workspace.package]\nversion = \"0.5.0\"\n"""
+        self.assertEqual(
+            release.workspace_manifest_with_version(manifest, "0.6.0-rc.1"),
+            """[workspace]\nversion = \"unrelated\"\n\n[workspace.package]\nversion = \"0.6.0-rc.1\"\n""",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- teach the release manager stable/RC version transitions, including `v0.6.0-rc.1`
- synchronize `VERSION`, the Cargo workspace version, and `Cargo.lock`
- publish hyphenated tags as GitHub prereleases and leave the stable Homebrew formula untouched
- upgrade the release action to its Node 24-compatible v3 line
- exercise version transitions in canonical CI and document the remaining Phase 6 gate

## Validation

- `python3 -m unittest scripts/test_release.py`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Rust-hosted PocketPy parses the complete release manager through the interactive selector

Tracks #13.