### PR TITLE
Publish verifiable Rust release evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           scripts/test_generate_stubs.py
           scripts/test_release.py
           scripts/test_release_notes.py
+          scripts/test_verify_pocketpy_patches.py
 
   ffi-sanitizers:
     name: PocketPy FFI sanitizers
@@ -229,7 +230,10 @@ jobs:
         with:
           python-version: "3.12"
       - name: Verify PocketPy vendor patchset
-        run: python3 scripts/verify-pocketpy-patches.py --check-upstream
+        run: >-
+          python3 scripts/verify-pocketpy-patches.py
+          --check-upstream
+          --report artifacts/pocketpy-patch-verification.json
       - name: Build canonical runtime
         run: cargo build --release -p ucharm-runtime
       - name: Run full compatibility report
@@ -237,10 +241,15 @@ jobs:
           python3 tests/compat_runner.py
           --runtime target/release/pocketpy-ucharm
           --report
-          --ci
       - name: Upload compatibility report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: compatibility-report
           path: tests/compat_report_pocketpy.md
+      - name: Upload PocketPy patch verification
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pocketpy-patch-verification
+          path: artifacts/pocketpy-patch-verification.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,9 +194,37 @@ jobs:
           name: cli-${{ matrix.suffix }}
           path: release-assets/
 
+  release-evidence:
+    name: Verify release evidence
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify and replay PocketPy vendor patchset
+        run: >-
+          python3 scripts/verify-pocketpy-patches.py
+          --check-upstream
+          --report release-evidence/pocketpy-patch-verification.json
+      - name: Build canonical runtime
+        run: cargo build --release -p ucharm-runtime
+      - name: Generate and enforce compatibility report
+        run: >-
+          python3 tests/compat_runner.py
+          --runtime target/release/pocketpy-ucharm
+          --report
+          --output release-evidence/compatibility-report.md
+      - name: Upload release evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-evidence
+          path: release-evidence/
+
   release:
     name: Create Release
-    needs: [build-components, build-cli]
+    needs: [build-components, build-cli, release-evidence]
     runs-on: ubuntu-latest
 
     steps:
@@ -216,9 +244,15 @@ jobs:
           find artifacts -type f \( \
             -name 'ucharm-*' -o \
             -name 'pocketpy-ucharm-*' -o \
-            -name 'loader-*' \
+            -name 'loader-*' -o \
+            -name 'compatibility-report.md' -o \
+            -name 'pocketpy-patch-verification.json' \
           \) -exec cp {} release/ \;
-          find release -type f ! -name '*.sha256' -exec chmod +x {} +
+          find release -type f \( \
+            -name 'ucharm-*' -o \
+            -name 'pocketpy-ucharm-*' -o \
+            -name 'loader-*' \
+          \) ! -name '*.sha256' -exec chmod +x {} +
           ls -la release
 
       - uses: actions/setup-python@v5

--- a/PLAN.md
+++ b/PLAN.md
@@ -51,10 +51,14 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
 - Maintain parity by re-running `python3 tests/compat_runner.py --report` after runtime changes.
 
 ### Phase 3: DX + packaging alignment
-- Align stubs with the PocketPy import surface and regenerate with a single command.
+- **Complete:** align stubs with the PocketPy import surface and regenerate
+  with a single command.
 - **Complete:** templates and examples reference the PocketPy runtime and the
   direct `tui`/`input` module interface.
-- Add CI target for PocketPy compatibility report generation.
+- **Complete:** CI generates and uploads the PocketPy compatibility report,
+  fails on compatibility regressions, and publishes a machine-readable proof
+  that the declared PocketPy patches replay onto pristine upstream and exactly
+  reconstruct the vendored source.
 
 ## What to Focus on Next
 
@@ -66,9 +70,9 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
 3. The archived Zig implementation is removed. The public README, website,
    docs, templates, and examples now describe the Rust architecture and RC;
    the website publishes the measured migration retrospective below.
-4. Canonical stub generation and CI drift checking are complete. Continue with
-   release-artifact/report verification, then promote 0.6 after the remaining
-   prerelease feedback and product-name review.
+4. Canonical stub generation, release evidence, and cross-target build
+   verification are complete. Promote 0.6 after the remaining prerelease
+   feedback and product-name review.
 
 ## Product Roadmap After the Rust Cutover
 
@@ -202,9 +206,15 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
   `tui`/`input` import paths.
 
 ### Phase E: Packaging + release hygiene
-- Add a CI step that runs `python3 tests/compat_runner.py --report` and uploads the report as an artifact.
-- Add a CI step that runs `python3 scripts/verify-pocketpy-patches.py --check-upstream`.
-- Validate cross-target build support (`ucharm build --targets` and a sample `--target` build).
+- **Complete:** CI runs the full compatibility report as a regression gate and
+  uploads it as an artifact. Tagged releases regenerate and publish that report.
+- **Complete:** CI checks the PocketPy anchors against pristine upstream,
+  replays every declared patch, requires the result to match the vendored
+  source byte for byte, and publishes the JSON verification record in tagged
+  releases.
+- **Complete:** `ucharm build --targets` is integration-tested, every embedded
+  target is packaged and trailer-verified, and native-architecture CI builds
+  and executes a sample `--target` universal application on all four targets.
 - Prefer native-architecture CI runners for C/Rust release builds; do not reintroduce Zig for cross-compilation.
 
 ## Backlog (ordered)

--- a/README.md
+++ b/README.md
@@ -300,6 +300,11 @@ Current compatibility summary (from `tests/compat_report_pocketpy.md`):
 - 7.044ms median / 7.980ms p95 native ARM64 startup and a 4,000,864-byte
   stripped runtime in the final 1,200-run migration sample
 
+CI treats compatibility as a regression gate and uploads the full report. Each
+tagged release also publishes that report plus a machine-readable verification
+that the declared PocketPy patch series reproduces the vendored source from the
+pristine upstream release.
+
 ## Showcase
 
 Built something with μcharm? Open a PR to add it here.

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -491,10 +491,10 @@ artifacts meet the compatibility, startup, and size gates.
     explicitly as improvements.
 - Resume roadmap work in this order:
   1. Rust-native optimization and dependency review — complete;
-  2. README/website/docs refresh and the migration retrospective;
+  2. README/website/docs refresh and the migration retrospective — complete;
   3. canonical stub generation and CI drift checking — complete;
-  4. compatibility report and PocketPy patch verification artifacts;
-  5. cross-target build reliability;
+  4. compatibility report and PocketPy patch verification artifacts — complete;
+  5. cross-target build reliability — complete;
   6. tree-shaking/module selection for size;
   7. `ucharm dev` watch mode;
   8. remaining networking, format, concurrency, and database work;

--- a/crates/ucharm-cli/tests/cli.rs
+++ b/crates/ucharm-cli/tests/cli.rs
@@ -26,6 +26,17 @@ fn reports_version_help_and_unknown_commands() {
     assert!(build_help.status.success());
     assert!(text(&build_help.stdout).contains("Build standalone binaries"));
 
+    let targets = run(&temporary, &["build", "--targets"]);
+    assert!(targets.status.success());
+    for target in [
+        "macos-aarch64",
+        "macos-x86_64",
+        "linux-aarch64",
+        "linux-x86_64",
+    ] {
+        assert!(text(&targets.stdout).contains(target), "missing {target}");
+    }
+
     let test_help = run(&temporary, &["test", "--help"]);
     assert!(test_help.status.success());
     assert!(text(&test_help.stdout).contains("CPython Compatibility Testing"));

--- a/scripts/test_verify_pocketpy_patches.py
+++ b/scripts/test_verify_pocketpy_patches.py
@@ -1,0 +1,90 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("verify-pocketpy-patches.py")
+SPEC = importlib.util.spec_from_file_location("verify_pocketpy_patches", SCRIPT)
+verify = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(verify)
+
+
+class PocketPyPatchVerificationTests(unittest.TestCase):
+    def test_replays_a_patch_and_requires_exact_vendor_output(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            source = root / "pocketpy/vendor/pocketpy.c"
+            source.parent.mkdir(parents=True)
+            source.write_text("before\n", encoding="utf-8")
+            patch = root / "pocketpy/patches/0001-change.patch"
+            patch.parent.mkdir(parents=True)
+            patch.write_text(
+                "diff --git a/pocketpy/vendor/pocketpy.c b/pocketpy/vendor/pocketpy.c\n"
+                "--- a/pocketpy/vendor/pocketpy.c\n"
+                "+++ b/pocketpy/vendor/pocketpy.c\n"
+                "@@ -1 +1 @@\n"
+                "-upstream\n"
+                "+before\n",
+                encoding="utf-8",
+            )
+            failures = []
+            self.assertTrue(
+                verify._replay_patchset(
+                    root,
+                    "upstream\n",
+                    [patch],
+                    [{"path": "pocketpy/vendor/pocketpy.c"}],
+                    failures,
+                )
+            )
+            self.assertEqual(failures, [])
+
+            source.write_text("different\n", encoding="utf-8")
+            failures = []
+            self.assertFalse(
+                verify._replay_patchset(
+                    root,
+                    "upstream\n",
+                    [patch],
+                    [{"path": "pocketpy/vendor/pocketpy.c"}],
+                    failures,
+                )
+            )
+            self.assertIn("differs from vendored", failures[0])
+
+    def test_manifest_requires_every_patch_on_disk(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            patch_directory = root / "pocketpy/patches"
+            patch_directory.mkdir(parents=True)
+            (patch_directory / "0001-declared.patch").write_text("declared\n")
+            (patch_directory / "0002-untracked.patch").write_text("untracked\n")
+            manifest = {
+                "patch_files": [
+                    {
+                        "id": "0001-declared",
+                        "file": "pocketpy/patches/0001-declared.patch",
+                    }
+                ],
+                "tracked_files": [{"path": "pocketpy/vendor/pocketpy.c"}],
+            }
+            failures = []
+            verify._validate_manifest(root, manifest, failures)
+            self.assertTrue(
+                any("differs from disk" in failure for failure in failures), failures
+            )
+
+    def test_json_report_is_deterministic_and_machine_readable(self):
+        with tempfile.TemporaryDirectory() as raw_directory:
+            report_path = Path(raw_directory) / "nested/report.json"
+            report = {"status": "pass", "schema_version": 1}
+            verify._write_report(report_path, report)
+            self.assertEqual(json.loads(report_path.read_text()), report)
+            self.assertTrue(report_path.read_text().endswith("\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-pocketpy-patches.py
+++ b/scripts/verify-pocketpy-patches.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import subprocess
 import sys
+import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -12,6 +15,10 @@ from pathlib import Path
 
 def _read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def _download_pocketpy_c(version: str) -> str:
@@ -24,14 +31,158 @@ def _download_pocketpy_c(version: str) -> str:
     return data.decode("utf-8", errors="replace")
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Verify μcharm PocketPy vendor patchset."
-    )
+def _repository_path(repo_root: Path, relative: str, failures: list[str]) -> Path | None:
+    path = (repo_root / relative).resolve()
+    try:
+        path.relative_to(repo_root.resolve())
+    except ValueError:
+        failures.append(f"manifest path escapes repository: {relative}")
+        return None
+    return path
+
+
+def _validate_manifest(
+    repo_root: Path, manifest: dict, failures: list[str]
+) -> tuple[list[Path], list[dict]]:
+    patch_entries = manifest.get("patch_files", [])
+    tracked_entries = manifest.get("tracked_files", [])
+    if not patch_entries:
+        failures.append("manifest has no patch_files")
+    if not tracked_entries:
+        failures.append("manifest has no tracked_files")
+
+    patch_paths: list[Path] = []
+    declared_files: list[str] = []
+    declared_ids: list[str] = []
+    for entry in patch_entries:
+        patch_id = entry.get("id")
+        relative = entry.get("file")
+        if not patch_id or not relative:
+            failures.append(f"invalid patch_files entry: {entry}")
+            continue
+        declared_ids.append(patch_id)
+        declared_files.append(relative)
+        if Path(relative).name != f"{patch_id}.patch":
+            failures.append(f"patch id and filename disagree: {patch_id}, {relative}")
+        path = _repository_path(repo_root, relative, failures)
+        if path is None:
+            continue
+        if not path.is_file():
+            failures.append(f"missing patch file: {relative}")
+            continue
+        patch_paths.append(path)
+
+    if len(declared_ids) != len(set(declared_ids)):
+        failures.append("manifest contains duplicate patch ids")
+    if len(declared_files) != len(set(declared_files)):
+        failures.append("manifest contains duplicate patch files")
+
+    patch_directory = repo_root / "pocketpy" / "patches"
+    actual_files = {
+        str(path.relative_to(repo_root)) for path in patch_directory.glob("*.patch")
+    }
+    declared_set = set(declared_files)
+    if actual_files != declared_set:
+        failures.append(
+            "manifest patch file set differs from disk: "
+            f"missing={sorted(actual_files - declared_set)}, "
+            f"extra={sorted(declared_set - actual_files)}"
+        )
+
+    return patch_paths, tracked_entries
+
+
+def _verify_tracked_files(
+    repo_root: Path, tracked: list[dict], failures: list[str]
+) -> list[dict]:
+    records = []
+    for entry in tracked:
+        relative = entry.get("path")
+        if not relative:
+            failures.append(f"invalid tracked_files entry: {entry}")
+            continue
+        path = _repository_path(repo_root, relative, failures)
+        if path is None:
+            continue
+        if not path.is_file():
+            failures.append(f"missing file: {relative}")
+            continue
+
+        text = _read_text(path)
+        anchors = entry.get("anchors", [])
+        if not anchors:
+            failures.append(f"tracked file has no anchors: {relative}")
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(f"missing anchor in {relative}: {anchor}")
+        records.append(
+            {
+                "path": relative,
+                "sha256": _sha256(path),
+                "anchor_count": len(anchors),
+            }
+        )
+    return records
+
+
+def _replay_patchset(
+    repo_root: Path,
+    upstream_text: str,
+    patch_paths: list[Path],
+    tracked: list[dict],
+    failures: list[str],
+) -> bool:
+    upstream_relative = Path("pocketpy/vendor/pocketpy.c")
+    with tempfile.TemporaryDirectory() as raw_directory:
+        replay_root = Path(raw_directory)
+        upstream_path = replay_root / upstream_relative
+        upstream_path.parent.mkdir(parents=True)
+        upstream_path.write_text(upstream_text, encoding="utf-8")
+
+        for patch_path in patch_paths:
+            try:
+                applied = subprocess.run(
+                    ["git", "apply", str(patch_path)],
+                    cwd=replay_root,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+            except FileNotFoundError:
+                failures.append("git is required to replay the PocketPy patchset")
+                return False
+            if applied.returncode != 0:
+                detail = applied.stderr.strip() or applied.stdout.strip()
+                failures.append(f"cannot replay {patch_path.name}: {detail}")
+                return False
+
+        matches = True
+        for entry in tracked:
+            relative = entry.get("path")
+            if not relative:
+                continue
+            replayed = replay_root / relative
+            vendored = repo_root / relative
+            if not replayed.is_file():
+                failures.append(f"patch replay did not produce tracked file: {relative}")
+                matches = False
+            elif replayed.read_bytes() != vendored.read_bytes():
+                failures.append(f"patch replay differs from vendored file: {relative}")
+                matches = False
+        return matches
+
+
+def _write_report(path: Path, report: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify μcharm PocketPy vendor patchset.")
     parser.add_argument(
         "--check-upstream",
         action="store_true",
-        help="Also verify the anchors are absent from pristine upstream PocketPy for this version.",
+        help="Verify anchors are absent upstream and replay patches onto pristine PocketPy.",
     )
     parser.add_argument(
         "--upstream-path",
@@ -44,7 +195,13 @@ def main() -> int:
         default=None,
         help="PocketPy version to check upstream against (defaults to pocketpy/POCKETPY_VERSION).",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Write a machine-readable JSON verification report.",
+    )
+    args = parser.parse_args(argv)
 
     repo_root = Path(__file__).resolve().parent.parent
     manifest_path = repo_root / "pocketpy" / "patches" / "manifest.json"
@@ -52,51 +209,44 @@ def main() -> int:
         print(f"error: missing manifest: {manifest_path}")
         return 2
 
-    manifest = json.loads(_read_text(manifest_path))
+    try:
+        manifest = json.loads(_read_text(manifest_path))
+    except json.JSONDecodeError as error:
+        print(f"error: invalid patch manifest: {error}")
+        return 2
+
     failures: list[str] = []
-
-    tracked = manifest.get("tracked_files", [])
-    for entry in tracked:
-        rel_path = entry.get("path")
-        if not rel_path:
-            continue
-        file_path = repo_root / rel_path
-        if not file_path.exists():
-            failures.append(f"missing file: {rel_path}")
-            continue
-
-        text = _read_text(file_path)
-        for anchor in entry.get("anchors", []):
-            if anchor not in text:
-                failures.append(f"missing anchor in {rel_path}: {anchor}")
+    patch_paths, tracked = _validate_manifest(repo_root, manifest, failures)
+    tracked_records = _verify_tracked_files(repo_root, tracked, failures)
+    version = args.pocketpy_version
+    replay_matches_vendor: bool | None = None
 
     if args.check_upstream:
-        vendor_anchors: list[str] = []
-        for entry in tracked:
-            vendor_anchors.extend(entry.get("anchors", []))
-
-        upstream_text: str
+        vendor_anchors = [
+            anchor for entry in tracked for anchor in entry.get("anchors", [])
+        ]
+        upstream_text = ""
         if args.upstream_path is not None:
-            upstream_text = _read_text(args.upstream_path)
+            try:
+                upstream_text = _read_text(args.upstream_path)
+            except OSError as error:
+                failures.append(f"failed to read upstream PocketPy: {error}")
         else:
-            version = args.pocketpy_version
             if version is None:
                 version_file = repo_root / "pocketpy" / "POCKETPY_VERSION"
                 if not version_file.exists():
                     failures.append(
                         "missing pocketpy/POCKETPY_VERSION (needed for --check-upstream)"
                     )
-                    upstream_text = ""
                 else:
                     version = version_file.read_text(encoding="utf-8").strip()
             if version:
                 try:
                     upstream_text = _download_pocketpy_c(version)
-                except (urllib.error.URLError, TimeoutError) as e:
+                except (urllib.error.URLError, TimeoutError) as error:
                     failures.append(
-                        f"failed to download upstream pocketpy.c for v{version}: {e}"
+                        f"failed to download upstream pocketpy.c for v{version}: {error}"
                     )
-                    upstream_text = ""
 
         if upstream_text:
             for anchor in vendor_anchors:
@@ -104,11 +254,37 @@ def main() -> int:
                     failures.append(
                         f"upstream contains vendor anchor unexpectedly: {anchor}"
                     )
-
             if "ucharm patch:" in upstream_text:
-                failures.append(
-                    "upstream contains 'ucharm patch:' markers unexpectedly"
-                )
+                failures.append("upstream contains 'ucharm patch:' markers unexpectedly")
+            replay_matches_vendor = _replay_patchset(
+                repo_root, upstream_text, patch_paths, tracked, failures
+            )
+
+    patch_records = [
+        {
+            "id": entry.get("id"),
+            "path": entry.get("file"),
+            "sha256": _sha256(repo_root / entry["file"])
+            if entry.get("file") and (repo_root / entry["file"]).is_file()
+            else None,
+        }
+        for entry in manifest.get("patch_files", [])
+    ]
+    report = {
+        "schema_version": 1,
+        "status": "fail" if failures else "pass",
+        "patchset_id": manifest.get("patchset_id"),
+        "patchset_version": manifest.get("patchset_version"),
+        "pocketpy_version": version,
+        "upstream_checked": args.check_upstream,
+        "replay_matches_vendor": replay_matches_vendor,
+        "patch_files": patch_records,
+        "tracked_files": tracked_records,
+        "failures": failures,
+    }
+    if args.report is not None:
+        _write_report(args.report, report)
+        print(f"Wrote patch verification report: {args.report}")
 
     if failures:
         print("PocketPy vendor patch verification failed:")
@@ -118,7 +294,8 @@ def main() -> int:
 
     patchset_id = manifest.get("patchset_id", "<unknown>")
     patchset_version = manifest.get("patchset_version", "<unknown>")
-    print(f"PocketPy vendor patches OK: {patchset_id} v{patchset_version}")
+    suffix = "; pristine replay matches vendor" if replay_matches_vendor else ""
+    print(f"PocketPy vendor patches OK: {patchset_id} v{patchset_version}{suffix}")
     return 0
 
 


### PR DESCRIPTION
## Summary

- replay the declared PocketPy patch series against pristine upstream and require a byte-for-byte match with the vendored source
- emit a machine-readable patch verification record with source and patch hashes
- make compatibility failures block CI and tagged releases while preserving report artifacts
- publish compatibility and patch-verification evidence with every GitHub release
- assert the public cross-target listing and mark the completed migration gates in the roadmap

## Validation

- just check
- full 1,669-check compatibility run without permissive CI mode
- upstream PocketPy v2.1.3 patch replay and JSON report validation
- repository Python tooling tests
- release and CI workflow YAML validation
- downloaded GitHub artifacts verified: 1,669/1,669 report and replay_matches_vendor=true

Continues the Rust migration closeout tracked in #13.