### PR TITLE
Use kipferl.dev as canonical domain

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -163,10 +163,10 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
 - **Engineering rename complete:** the project is now Kipferl, the repository
   lives at `niklas-heer/kipferl`, and the Rust packages, binaries, release
   assets, site, docs, templates, and visual identity use the new name. Package
-  namespaces and the planned `getkipferl.org` home were available when checked.
-  Register the domain and complete formal legal clearance before the public
-  stable launch. Keep the compatibility aliases for the documented 0.6 window;
-  the frozen `MCHARM01` format remains unchanged.
+  namespaces were available when checked, and `kipferl.dev` is now registered
+  as the public home. Complete formal legal clearance before the public stable
+  launch. Keep the compatibility aliases for the documented 0.6 window; the
+  frozen `MCHARM01` format remains unchanged.
 - **Complete:** the README, website, user docs, generated-project templates,
   and examples now use the Rust architecture, direct `tui`/`input` imports,
   measured performance/size claims, and real architecture-specific RC assets.

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Uploading  [███████████░░░░░░] 68%  3.2s
 Kipferl is the new name for μcharm beginning with the Rust-based 0.6 release.
 The pastry name is a small nod to Bun and a literal fit for the product: Kipferl
 *bakes* a Python-style CLI into one portable executable. The repository, binary,
-packages, and documentation now share the same spelling, and the planned public
-home is [getkipferl.org](https://getkipferl.org).
+packages, and documentation now share the same spelling, with
+[kipferl.dev](https://kipferl.dev) as the public home.
 
 Existing 0.5 users have a gentle transition. The 0.6 release accepts old
 `from ucharm ...` imports and environment variables, publishes temporary
@@ -307,7 +307,7 @@ The shipping implementation is Rust around an embedded PocketPy C runtime:
 The migration was compatibility-gated rather than rewritten behind a flag day.
 Read [the migration plan](RUST_MIGRATION.md), the
 [optimization record](benchmarks/rust_optimization_baseline.md), and the
-[public retrospective](https://getkipferl.org/blog/rust-migration) for the why,
+[public retrospective](https://kipferl.dev/blog/rust-migration) for the why,
 the incremental process, accepted tradeoffs, and final measurements.
 
 Current compatibility summary (from `tests/compat_report_pocketpy.md`):
@@ -402,7 +402,7 @@ See `tests/compat_report_pocketpy.md` for detailed module compatibility.
 
 ## Docs
 
-- [Website documentation](https://getkipferl.org/docs)
+- [Website documentation](https://kipferl.dev/docs)
 - [Product direction](vision.md)
 - [Implementation priorities](PLAN.md)
 - [Rust migration record](RUST_MIGRATION.md)

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -44,7 +44,7 @@ mkdir -p "$(dirname "$FORMULA_PATH")"
 cat > "$FORMULA_PATH" << EOF
 class Kipferl < Formula
   desc "Bake Python CLI apps into fast standalone binaries"
-  homepage "https://getkipferl.org"
+  homepage "https://kipferl.dev"
   version "$VERSION"
   license "MIT"
 

--- a/website/src/app/blog/rust-migration/page.tsx
+++ b/website/src/app/blog/rust-migration/page.tsx
@@ -114,7 +114,7 @@ export default function RustMigrationPage() {
             name. A Kipferl is a crescent-shaped pastry, giving a small nod to
             Bun and matching the product metaphor: we bake a Python-style CLI
             into one portable executable. The repository, command, packages, and
-            planned home at getkipferl.org now use one memorable spelling.
+            public home at kipferl.dev now use one memorable spelling.
           </p>
           <p>
             The rename is intentionally compatible. Version 0.6 keeps the old

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://getkipferl.org"),
+  metadataBase: new URL("https://kipferl.dev"),
   title: {
     default: "Kipferl — Python CLIs, standalone binaries",
     template: "%s | Kipferl",


### PR DESCRIPTION
## What changed

- replace the planned `getkipferl.org` URL with the registered `kipferl.dev` domain
- update website metadata and migration retrospective copy
- update the generated Homebrew formula homepage
- record the registration in the migration plan

## Why

`kipferl.dev` is now registered and should be the single canonical public URL before the RC release.

## Validation

- `npm run lint`
- `npm run types:check`
- `npm run build`
- `bash -n scripts/update-homebrew.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project and migration documentation to identify `kipferl.dev` as the public website.
  * Updated website links, blog content, and site metadata to use the new domain.
  * Updated generated Homebrew formula homepage links.
  * Clarified that formal legal clearance is still required before stable launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->