### PR TITLE
Add kipferl dev watch mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -354,6 +354,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "getrandom"
@@ -445,6 +454,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.13.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +554,8 @@ name = "kipferl-cli"
 version = "0.6.0-rc.2"
 dependencies = [
  "kipferl-format",
+ "libc",
+ "notify",
  "sha2",
 ]
 
@@ -564,6 +595,26 @@ dependencies = [
  "tar",
  "ureq",
  "zip",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
 ]
 
 [[package]]
@@ -670,6 +721,33 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -936,7 +1014,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -985,6 +1063,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1299,6 +1386,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,7 +1453,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1365,14 +1480,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1382,10 +1514,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1394,10 +1538,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1406,10 +1562,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1418,10 +1586,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "zeroize"

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -24,10 +24,11 @@ adoption for CLI tools.
 - Robust subprocess (argv fidelity, large output handling).
 - Config parsing: `configparser` plus `toml` or a tiny `fetch` module.
 - Unicode width handling for aligned tables/boxes.
+- Fast local feedback through `kipferl dev` watch/restart mode.
 
 ### Docs
 
-- Quickstart (hello + build + run).
+- Quickstart (hello + develop + build + run).
 - Limitations (no pip) and module tiers.
 - CLI cookbook (common patterns: config, logging, subprocess, progress).
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -27,6 +27,9 @@ This is the single source of truth for priorities and next steps.
 - Phase 6 has cut the canonical CI, release workflow, embedded assets, public
   binary names, local commands, and contributor guidance over to Rust/Cargo.
 - The Rust optimization, safety, native CI, and prerelease gates are complete.
+- `kipferl dev` provides a Rust-native watch/restart loop with debounced native
+  filesystem events, extra watch paths, terminal clearing, and terminal-state
+  restoration for interactive applications.
 - The archived Zig implementation has been removed from the working tree; use
   final Zig tag `v0.5.0` for archaeology.
 - Preserve PocketPy, the Python-facing API, `MCHARM01` universal binaries, and all current compatibility tests.
@@ -71,8 +74,9 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
    docs, templates, and examples now describe the Rust architecture and RC;
    the website publishes the measured migration retrospective below.
 4. Canonical stub generation, release evidence, and cross-target build
-   verification are complete. Promote 0.6 after the remaining prerelease
-   feedback and product-name review.
+   verification are complete. Publish and validate `v0.6.0-rc.2` with
+   `kipferl dev`, allow a short feedback window, then promote the same proven
+   Rust line to stable `v0.6.0`.
 
 ## Product Roadmap After the Rust Cutover
 
@@ -207,6 +211,11 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
   now use `http.client`.
 - **Complete:** templates and docs reference the canonical stubs and direct
   `tui`/`input` import paths.
+- **Complete:** `kipferl dev` runs a script immediately, watches its project
+  directory through `notify`'s native macOS/Linux backends, debounces editor
+  event bursts, supports repeatable `--watch` paths and `--clear`, remains
+  alive after script exit, and restores terminal settings between interactive
+  restarts. Parser, filtering, help, and real edit/restart behavior are tested.
 
 ### Phase E: Packaging + release hygiene
 - **Complete:** CI runs the full compatibility report as a regression gate and
@@ -222,8 +231,10 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
 
 ## Backlog (ordered)
 
-- Tree-shaking or module selection for smaller binaries.
-- `kipferl dev` (watch mode / hot reload).
+- Publish and validate `v0.6.0-rc.2`, then promote the proven Rust release to
+  stable `v0.6.0` after its feedback window.
+- Tree-shaking or module selection for smaller binaries, after stable; pursue
+  it only when the DX and maintenance tradeoff is favorable.
 - Formats: third-party `toml` and YAML.
 - Concurrency: `threading`, `queue` (PocketPy threading support TBD).
 - Database: expand the current bounded `sqlite3` subset only behind compatibility and artifact-size gates.

--- a/README.md
+++ b/README.md
@@ -36,13 +36,19 @@ scripts, and Kipferl ships them as single-file binaries that start instantly.
 ## Quickstart
 
 ```bash
-# Run a script
-kipferl run app.py
+# Develop with automatic restart on every edit
+kipferl dev app.py
 
 # Build a standalone binary
 kipferl build app.py -o app
 ./app
 ```
+
+`kipferl dev` watches Python, config, and template files under the script
+directory and keeps waiting after the program exits. Use `--watch <path>` for
+additional files or directories (including other file types),
+`--clear` for a clean screen on each restart, or `--debounce <ms>` for tools
+that write files in bursts. Run `kipferl dev --help` for the complete interface.
 
 ---
 

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -498,10 +498,14 @@ artifacts meet the compatibility, startup, and size gates.
   3. canonical stub generation and CI drift checking — complete;
   4. compatibility report and PocketPy patch verification artifacts — complete;
   5. cross-target build reliability — complete;
-  6. tree-shaking/module selection for size;
-  7. `kipferl dev` watch mode;
-  8. remaining networking, format, concurrency, and database work;
-  9. higher-level TUI features from `vision.md`.
+  6. `kipferl dev` watch mode — complete for RC2 with native filesystem events,
+     debouncing, extra watch paths, terminal clearing/restoration, and an
+     end-to-end restart test;
+  7. publish and validate RC2, then promote the proven Rust line to stable;
+  8. tree-shaking/module selection for size, when its DX and maintenance value
+     justifies the complexity;
+  9. remaining networking, format, concurrency, and database work;
+  10. higher-level TUI features from `vision.md`.
 
 ## Suggested PR Sequence
 

--- a/crates/kipferl-cli/Cargo.toml
+++ b/crates/kipferl-cli/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+libc = "0.2"
+notify = "8.2"
 sha2 = "0.11"
 kipferl-format = { path = "../kipferl-format" }
 

--- a/crates/kipferl-cli/src/dev_command.rs
+++ b/crates/kipferl-cli/src/dev_command.rs
@@ -1,0 +1,563 @@
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::io::{self, IsTerminal, Write};
+use std::mem::MaybeUninit;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::{Duration, Instant};
+
+use notify::{Event, EventKind, RecursiveMode, Watcher};
+
+use crate::run_command;
+
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const RED: &str = "\x1b[31m";
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const CYAN: &str = "\x1b[36m";
+const DEFAULT_DEBOUNCE_MS: u64 = 150;
+const LOOP_INTERVAL: Duration = Duration::from_millis(25);
+const IGNORED_COMPONENTS: &[&str] = &[
+    ".git",
+    ".hg",
+    ".svn",
+    ".kipferl",
+    ".venv",
+    "venv",
+    "target",
+    "__pycache__",
+    "node_modules",
+];
+const PROJECT_EXTENSIONS: &[&str] = &[
+    "py", "pyi", "toml", "json", "yaml", "yml", "ini", "cfg", "conf", "html", "htm", "css",
+    "jinja", "jinja2", "j2",
+];
+
+#[derive(Debug, Eq, PartialEq)]
+struct Options {
+    script: PathBuf,
+    script_arguments: Vec<String>,
+    watch_paths: Vec<PathBuf>,
+    clear: bool,
+    debounce: Duration,
+}
+
+#[derive(Debug)]
+struct WatchTarget {
+    requested: PathBuf,
+    root: PathBuf,
+    exact_file: Option<PathBuf>,
+    project_files_only: bool,
+}
+
+pub fn execute(
+    arguments: &[String],
+    current_directory: &Path,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> io::Result<u8> {
+    if arguments
+        .first()
+        .is_some_and(|value| matches!(value.as_str(), "-h" | "--help"))
+    {
+        write!(stdout, "{}", help())?;
+        return Ok(0);
+    }
+
+    let options = match parse_options(arguments) {
+        Ok(options) => options,
+        Err(message) => {
+            writeln!(stderr, "{RED}Error:{RESET} {message}")?;
+            writeln!(
+                stderr,
+                "Usage: kipferl dev [OPTIONS] <script.py> [--] [args...]"
+            )?;
+            return Ok(1);
+        }
+    };
+    let script_path = current_directory.join(&options.script);
+    if !script_path.is_file() {
+        writeln!(
+            stderr,
+            "{RED}Error:{RESET} Script not found: {}",
+            options.script.display()
+        )?;
+        return Ok(1);
+    }
+
+    let targets = match resolve_targets(&script_path, &options.watch_paths, current_directory) {
+        Ok(targets) => targets,
+        Err(message) => {
+            writeln!(stderr, "{RED}Error:{RESET} {message}")?;
+            return Ok(1);
+        }
+    };
+    let runtime_path = match run_command::prepare_runtime() {
+        Ok(path) => path,
+        Err(error) => {
+            writeln!(
+                stderr,
+                "{RED}Error:{RESET} Failed to extract pocketpy: {error}"
+            )?;
+            return Ok(1);
+        }
+    };
+
+    let (sender, receiver) = mpsc::channel();
+    let mut watcher = notify::recommended_watcher(sender).map_err(watch_error)?;
+    let mut watched_roots = HashSet::new();
+    for target in &targets {
+        if watched_roots.insert(target.root.clone()) {
+            watcher
+                .watch(&target.root, RecursiveMode::Recursive)
+                .map_err(watch_error)?;
+        }
+    }
+
+    writeln!(
+        stdout,
+        "{GREEN}{BOLD}Kipferl dev{RESET} {DIM}watching {}{}",
+        targets[0].requested.display(),
+        if targets.len() == 1 {
+            String::new()
+        } else {
+            format!(" and {} more", targets.len() - 1)
+        }
+    )?;
+    stdout.flush()?;
+
+    let terminal = TerminalState::capture();
+    let mut child = Some(spawn_script(
+        &runtime_path,
+        &script_path,
+        &options.script_arguments,
+        current_directory,
+        stdout,
+    )?);
+    let mut restart_at = None;
+    let mut reported_exit = false;
+
+    loop {
+        match receiver.recv_timeout(LOOP_INTERVAL) {
+            Ok(Ok(event)) if event_requires_restart(&event, &targets) => {
+                restart_at = Some(Instant::now() + options.debounce);
+            }
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => {
+                writeln!(stderr, "{YELLOW}Watch warning:{RESET} {error}")?;
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => {
+                stop_child(&mut child, terminal.as_ref());
+                writeln!(
+                    stderr,
+                    "{RED}Error:{RESET} File watcher stopped unexpectedly"
+                )?;
+                return Ok(1);
+            }
+        }
+
+        if let Some(running) = child.as_mut()
+            && let Some(status) = running.try_wait()?
+        {
+            terminal.as_ref().map(TerminalState::restore);
+            if !reported_exit {
+                report_exit(stdout, status)?;
+                reported_exit = true;
+            }
+            child = None;
+        }
+
+        if restart_at.is_some_and(|deadline| Instant::now() >= deadline) {
+            restart_at = None;
+            stop_child(&mut child, terminal.as_ref());
+            if options.clear {
+                write!(stdout, "\x1b[2J\x1b[H")?;
+            }
+            writeln!(stdout, "{CYAN}{BOLD}↻{RESET} Change detected, restarting…")?;
+            stdout.flush()?;
+            child = match spawn_script(
+                &runtime_path,
+                &script_path,
+                &options.script_arguments,
+                current_directory,
+                stdout,
+            ) {
+                Ok(running) => {
+                    reported_exit = false;
+                    Some(running)
+                }
+                Err(error) => {
+                    writeln!(
+                        stderr,
+                        "{YELLOW}Restart failed:{RESET} {error}. Waiting for changes…"
+                    )?;
+                    reported_exit = true;
+                    None
+                }
+            };
+        }
+    }
+}
+
+fn parse_options(arguments: &[String]) -> Result<Options, String> {
+    let mut watch_paths = Vec::new();
+    let mut clear = false;
+    let mut debounce = Duration::from_millis(DEFAULT_DEBOUNCE_MS);
+    let mut index = 0;
+
+    while let Some(argument) = arguments.get(index) {
+        match argument.as_str() {
+            "-w" | "--watch" => {
+                index += 1;
+                let path = arguments
+                    .get(index)
+                    .ok_or_else(|| format!("{argument} requires a path"))?;
+                watch_paths.push(PathBuf::from(path));
+            }
+            "--clear" => clear = true,
+            "--debounce" => {
+                index += 1;
+                let value = arguments
+                    .get(index)
+                    .ok_or_else(|| "--debounce requires milliseconds".to_owned())?;
+                let milliseconds = value
+                    .parse::<u64>()
+                    .map_err(|_| "--debounce must be a non-negative integer".to_owned())?;
+                if milliseconds > 60_000 {
+                    return Err("--debounce cannot exceed 60000 milliseconds".to_owned());
+                }
+                debounce = Duration::from_millis(milliseconds);
+            }
+            "--" => return Err("no script specified before '--'".to_owned()),
+            option if option.starts_with('-') => {
+                return Err(format!("unknown option '{option}'"));
+            }
+            script => {
+                let mut script_arguments = arguments[index + 1..].to_vec();
+                if script_arguments.first().is_some_and(|value| value == "--") {
+                    script_arguments.remove(0);
+                }
+                return Ok(Options {
+                    script: PathBuf::from(script),
+                    script_arguments,
+                    watch_paths,
+                    clear,
+                    debounce,
+                });
+            }
+        }
+        index += 1;
+    }
+
+    Err("no script specified".to_owned())
+}
+
+fn resolve_targets(
+    script_path: &Path,
+    extra_paths: &[PathBuf],
+    current_directory: &Path,
+) -> Result<Vec<WatchTarget>, String> {
+    let script_parent = script_path
+        .parent()
+        .ok_or_else(|| "script has no parent directory".to_owned())?;
+    let mut targets = vec![directory_target(script_parent, true)?];
+
+    for path in extra_paths {
+        let requested = current_directory.join(path);
+        let metadata = requested
+            .metadata()
+            .map_err(|error| format!("cannot watch {}: {error}", path.display()))?;
+        if metadata.is_dir() {
+            targets.push(directory_target(&requested, false)?);
+        } else if metadata.is_file() {
+            let exact_file = canonical(&requested)?;
+            let root = exact_file
+                .parent()
+                .ok_or_else(|| format!("watch path has no parent: {}", path.display()))?
+                .to_owned();
+            targets.push(WatchTarget {
+                requested: path.clone(),
+                root,
+                exact_file: Some(exact_file),
+                project_files_only: false,
+            });
+        } else {
+            return Err(format!(
+                "watch path is not a file or directory: {}",
+                path.display()
+            ));
+        }
+    }
+    Ok(targets)
+}
+
+fn directory_target(path: &Path, project_files_only: bool) -> Result<WatchTarget, String> {
+    let root = canonical(path)?;
+    Ok(WatchTarget {
+        requested: root.clone(),
+        root,
+        exact_file: None,
+        project_files_only,
+    })
+}
+
+fn canonical(path: &Path) -> Result<PathBuf, String> {
+    path.canonicalize()
+        .map_err(|error| format!("cannot watch {}: {error}", path.display()))
+}
+
+fn event_requires_restart(event: &Event, targets: &[WatchTarget]) -> bool {
+    if matches!(event.kind, EventKind::Access(_)) {
+        return false;
+    }
+    event
+        .paths
+        .iter()
+        .any(|path| targets.iter().any(|target| target_matches(path, target)))
+}
+
+fn target_matches(path: &Path, target: &WatchTarget) -> bool {
+    if let Some(file) = &target.exact_file {
+        return path == file;
+    }
+    path.strip_prefix(&target.root).is_ok_and(|relative| {
+        !is_ignored(relative) && (!target.project_files_only || is_project_file(relative))
+    })
+}
+
+fn is_project_file(path: &Path) -> bool {
+    path.file_name().is_some_and(|name| name == ".env")
+        || path
+            .extension()
+            .and_then(OsStr::to_str)
+            .is_some_and(|extension| {
+                PROJECT_EXTENSIONS
+                    .iter()
+                    .any(|candidate| extension.eq_ignore_ascii_case(candidate))
+            })
+}
+
+fn is_ignored(path: &Path) -> bool {
+    path.components().any(|component| {
+        let value = component.as_os_str();
+        IGNORED_COMPONENTS
+            .iter()
+            .any(|ignored| value == OsStr::new(ignored))
+            || value == OsStr::new(".DS_Store")
+    })
+}
+
+fn spawn_script(
+    runtime_path: &Path,
+    script_path: &Path,
+    script_arguments: &[String],
+    current_directory: &Path,
+    stdout: &mut dyn Write,
+) -> io::Result<Child> {
+    let transformed_path = run_command::prepare_transformed_script(script_path)?;
+    writeln!(
+        stdout,
+        "{CYAN}→{RESET} Running {BOLD}{}{RESET}",
+        script_path.display()
+    )?;
+    stdout.flush()?;
+    Command::new(runtime_path)
+        .arg(transformed_path)
+        .args(script_arguments)
+        .current_dir(current_directory)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|error| io::Error::new(error.kind(), format!("failed to start script: {error}")))
+}
+
+fn stop_child(child: &mut Option<Child>, terminal: Option<&TerminalState>) {
+    if let Some(mut running) = child.take() {
+        let _ = running.kill();
+        let _ = running.wait();
+    }
+    if let Some(terminal) = terminal {
+        terminal.restore();
+    }
+}
+
+fn report_exit(stdout: &mut dyn Write, status: ExitStatus) -> io::Result<()> {
+    let status = status.code().map_or_else(
+        || "from a signal".to_owned(),
+        |code| format!("with code {code}"),
+    );
+    writeln!(
+        stdout,
+        "{DIM}Process exited {status}. Waiting for changes…{RESET}"
+    )?;
+    stdout.flush()
+}
+
+fn watch_error(error: notify::Error) -> io::Error {
+    io::Error::other(format!("file watcher: {error}"))
+}
+
+struct TerminalState(libc::termios);
+
+impl TerminalState {
+    fn capture() -> Option<Self> {
+        if !io::stdin().is_terminal() {
+            return None;
+        }
+        let mut settings = MaybeUninit::<libc::termios>::uninit();
+        // SAFETY: `settings` points to writable storage and stdin is a valid
+        // descriptor. A zero return initializes the entire value.
+        if unsafe { libc::tcgetattr(libc::STDIN_FILENO, settings.as_mut_ptr()) } != 0 {
+            return None;
+        }
+        // SAFETY: the successful `tcgetattr` call initialized `settings`.
+        Some(Self(unsafe { settings.assume_init() }))
+    }
+
+    fn restore(&self) {
+        // SAFETY: the settings were captured from this terminal and remain
+        // initialized for the duration of the call.
+        unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSAFLUSH, &self.0) };
+        eprint!("\x1b[0m\x1b[?25h");
+    }
+}
+
+pub fn help() -> String {
+    format!(
+        "{BOLD}Kipferl dev{RESET} - Restart a script when project files change\n\n{DIM}USAGE:{RESET}\n    kipferl dev [OPTIONS] <script.py> [--] [args...]\n\n{DIM}OPTIONS:{RESET}\n    -w, --watch <path>    Watch an additional file or directory\n    --clear               Clear the terminal before each restart\n    --debounce <ms>       Wait for writes to settle (default: 150)\n    -h, --help            Show this help\n\n{DIM}DESCRIPTION:{RESET}\n    Runs the script immediately, then watches its directory recursively.\n    The watcher stays alive when the script exits so the next edit runs it\n    again. Generated, cache, virtual-environment, and VCS paths are ignored.\n\n{DIM}EXAMPLES:{RESET}\n    kipferl dev app.py\n    kipferl dev --clear app.py\n    kipferl dev --watch templates --watch settings.toml app.py -- --verbose\n"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Options, WatchTarget, event_requires_restart, is_ignored, parse_options};
+    use notify::{Event, EventKind};
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    #[test]
+    fn parses_options_and_preserves_script_arguments() {
+        assert_eq!(
+            parse_options(&[
+                "--clear".into(),
+                "--watch".into(),
+                "templates".into(),
+                "--debounce".into(),
+                "75".into(),
+                "app.py".into(),
+                "--".into(),
+                "--verbose".into(),
+            ]),
+            Ok(Options {
+                script: PathBuf::from("app.py"),
+                script_arguments: vec!["--verbose".into()],
+                watch_paths: vec![PathBuf::from("templates")],
+                clear: true,
+                debounce: Duration::from_millis(75),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_incomplete_or_unknown_options() {
+        assert_eq!(parse_options(&[]), Err("no script specified".into()));
+        assert_eq!(
+            parse_options(&["--watch".into()]),
+            Err("--watch requires a path".into())
+        );
+        assert_eq!(
+            parse_options(&["--debounce".into(), "soon".into(), "app.py".into()]),
+            Err("--debounce must be a non-negative integer".into())
+        );
+        assert_eq!(
+            parse_options(&["--debounce".into(), "60001".into(), "app.py".into()]),
+            Err("--debounce cannot exceed 60000 milliseconds".into())
+        );
+        assert_eq!(
+            parse_options(&["--wat".into(), "app.py".into()]),
+            Err("unknown option '--wat'".into())
+        );
+    }
+
+    #[test]
+    fn filters_access_and_generated_path_events() {
+        let target = WatchTarget {
+            requested: PathBuf::from("/project"),
+            root: PathBuf::from("/project"),
+            exact_file: None,
+            project_files_only: true,
+        };
+        let modified = Event::new(EventKind::Any).add_path(PathBuf::from("/project/app.py"));
+        assert!(event_requires_restart(&modified, &[target]));
+
+        let ignored =
+            Event::new(EventKind::Any).add_path(PathBuf::from("/project/__pycache__/app.pyc"));
+        assert!(is_ignored(&ignored.paths[0]));
+        assert!(!event_requires_restart(
+            &ignored,
+            &[WatchTarget {
+                requested: PathBuf::from("/project"),
+                root: PathBuf::from("/project"),
+                exact_file: None,
+                project_files_only: true,
+            }]
+        ));
+
+        let accessed = Event::new(EventKind::Access(notify::event::AccessKind::Any))
+            .add_path(PathBuf::from("/project/app.py"));
+        assert!(!event_requires_restart(
+            &accessed,
+            &[WatchTarget {
+                requested: PathBuf::from("/project"),
+                root: PathBuf::from("/project"),
+                exact_file: None,
+                project_files_only: true,
+            }]
+        ));
+    }
+
+    #[test]
+    fn exact_file_targets_do_not_restart_for_neighbors() {
+        let target = WatchTarget {
+            requested: PathBuf::from("settings.toml"),
+            root: PathBuf::from("/project"),
+            exact_file: Some(PathBuf::from("/project/settings.toml")),
+            project_files_only: false,
+        };
+        let neighbor = Event::new(EventKind::Any).add_path(PathBuf::from("/project/other.toml"));
+        assert!(!event_requires_restart(&neighbor, &[target]));
+    }
+
+    #[test]
+    fn ignored_parent_names_do_not_hide_the_watched_root() {
+        let target = WatchTarget {
+            requested: PathBuf::from("/target/project"),
+            root: PathBuf::from("/target/project"),
+            exact_file: None,
+            project_files_only: true,
+        };
+        let modified = Event::new(EventKind::Any).add_path(PathBuf::from("/target/project/app.py"));
+        assert!(event_requires_restart(&modified, &[target]));
+    }
+
+    #[test]
+    fn default_watch_ignores_application_output_but_keeps_project_files() {
+        let target = || WatchTarget {
+            requested: PathBuf::from("/project"),
+            root: PathBuf::from("/project"),
+            exact_file: None,
+            project_files_only: true,
+        };
+        let database = Event::new(EventKind::Any).add_path(PathBuf::from("/project/app.db"));
+        assert!(!event_requires_restart(&database, &[target()]));
+        let module = Event::new(EventKind::Any).add_path(PathBuf::from("/project/lib/helpers.py"));
+        assert!(event_requires_restart(&module, &[target()]));
+        let config = Event::new(EventKind::Any).add_path(PathBuf::from("/project/config.toml"));
+        assert!(event_requires_restart(&config, &[target()]));
+    }
+}

--- a/crates/kipferl-cli/src/lib.rs
+++ b/crates/kipferl-cli/src/lib.rs
@@ -1,4 +1,5 @@
 mod build_command;
+mod dev_command;
 mod project;
 mod run_command;
 mod test_command;
@@ -51,6 +52,7 @@ pub fn run(
         "new" => run_new(&arguments[1..], current_directory, stdout, stderr),
         "init" => run_init(&arguments[1..], current_directory, stdout, stderr),
         "run" => run_command::execute(&arguments[1..], current_directory, stdout, stderr),
+        "dev" => dev_command::execute(&arguments[1..], current_directory, stdout, stderr),
         "build" => build_command::execute(&arguments[1..], current_directory, stdout, stderr),
         "test" => test_command::execute(&arguments[1..], current_directory, stdout, stderr),
         unknown => {
@@ -282,7 +284,7 @@ fn print_new_logo(output: &mut dyn Write) -> io::Result<()> {
 
 fn main_help() -> String {
     format!(
-        "{BOLD}USAGE{RESET}\n    kipferl {CYAN}<command>{RESET} [options]\n\n{BOLD}COMMANDS{RESET}\n    {CYAN}new{RESET} {DIM}<name>{RESET}        Create a new project\n    {CYAN}run{RESET} {DIM}<file>{RESET}        Run a script with pocketpy\n    {CYAN}build{RESET} {DIM}<file>{RESET}      Build a standalone binary\n    {CYAN}init{RESET}              Initialize kipferl in current directory\n    {CYAN}test{RESET}              Run compatibility tests\n\n{BOLD}OPTIONS{RESET}\n    {CYAN}-h{RESET}, {CYAN}--help{RESET}        Show this help\n    {CYAN}-v{RESET}, {CYAN}--version{RESET}     Show version\n\n{BOLD}EXAMPLES{RESET}\n    {DIM}${RESET} kipferl new myapp                  {DIM}# Create new project{RESET}\n    {DIM}${RESET} kipferl run app.py                 {DIM}# Run with pocketpy{RESET}\n    {DIM}${RESET} kipferl build app.py -o app        {DIM}# Build universal binary{RESET}\n    {DIM}${RESET} kipferl init --stubs --ai claude   {DIM}# Add IDE support{RESET}\n\n{DIM}    Docs: https://github.com/niklas-heer/kipferl{RESET}\n"
+        "{BOLD}USAGE{RESET}\n    kipferl {CYAN}<command>{RESET} [options]\n\n{BOLD}COMMANDS{RESET}\n    {CYAN}new{RESET} {DIM}<name>{RESET}        Create a new project\n    {CYAN}run{RESET} {DIM}<file>{RESET}        Run a script with pocketpy\n    {CYAN}dev{RESET} {DIM}<file>{RESET}        Run and restart when files change\n    {CYAN}build{RESET} {DIM}<file>{RESET}      Build a standalone binary\n    {CYAN}init{RESET}              Initialize kipferl in current directory\n    {CYAN}test{RESET}              Run compatibility tests\n\n{BOLD}OPTIONS{RESET}\n    {CYAN}-h{RESET}, {CYAN}--help{RESET}        Show this help\n    {CYAN}-v{RESET}, {CYAN}--version{RESET}     Show version\n\n{BOLD}EXAMPLES{RESET}\n    {DIM}${RESET} kipferl new myapp                  {DIM}# Create new project{RESET}\n    {DIM}${RESET} kipferl dev app.py                 {DIM}# Develop with live restart{RESET}\n    {DIM}${RESET} kipferl build app.py -o app        {DIM}# Build universal binary{RESET}\n    {DIM}${RESET} kipferl init --stubs --ai claude   {DIM}# Add IDE support{RESET}\n\n{DIM}    Docs: https://kipferl.dev{RESET}\n"
     )
 }
 
@@ -301,7 +303,8 @@ fn init_help() -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_command, init_help, main_help, new_help, project::sanitize_name, run_command,
+        build_command, dev_command, init_help, main_help, new_help, project::sanitize_name,
+        run_command,
     };
 
     #[test]
@@ -314,6 +317,7 @@ mod tests {
                 "\x1b[1mCOMMANDS\x1b[0m\n",
                 "    \x1b[36mnew\x1b[0m \x1b[2m<name>\x1b[0m        Create a new project\n",
                 "    \x1b[36mrun\x1b[0m \x1b[2m<file>\x1b[0m        Run a script with pocketpy\n",
+                "    \x1b[36mdev\x1b[0m \x1b[2m<file>\x1b[0m        Run and restart when files change\n",
                 "    \x1b[36mbuild\x1b[0m \x1b[2m<file>\x1b[0m      Build a standalone binary\n",
                 "    \x1b[36minit\x1b[0m              Initialize kipferl in current directory\n",
                 "    \x1b[36mtest\x1b[0m              Run compatibility tests\n\n",
@@ -322,10 +326,10 @@ mod tests {
                 "    \x1b[36m-v\x1b[0m, \x1b[36m--version\x1b[0m     Show version\n\n",
                 "\x1b[1mEXAMPLES\x1b[0m\n",
                 "    \x1b[2m$\x1b[0m kipferl new myapp                  \x1b[2m# Create new project\x1b[0m\n",
-                "    \x1b[2m$\x1b[0m kipferl run app.py                 \x1b[2m# Run with pocketpy\x1b[0m\n",
+                "    \x1b[2m$\x1b[0m kipferl dev app.py                 \x1b[2m# Develop with live restart\x1b[0m\n",
                 "    \x1b[2m$\x1b[0m kipferl build app.py -o app        \x1b[2m# Build universal binary\x1b[0m\n",
                 "    \x1b[2m$\x1b[0m kipferl init --stubs --ai claude   \x1b[2m# Add IDE support\x1b[0m\n\n",
-                "\x1b[2m    Docs: https://github.com/niklas-heer/kipferl\x1b[0m\n",
+                "\x1b[2m    Docs: https://kipferl.dev\x1b[0m\n",
             )
         );
         assert_eq!(
@@ -396,6 +400,27 @@ mod tests {
                 "    kipferl run app.py\n",
                 "    kipferl run app.py --verbose\n",
                 "    kipferl run examples/demo.py\n",
+            )
+        );
+        assert_eq!(
+            dev_command::help(),
+            concat!(
+                "\x1b[1mKipferl dev\x1b[0m - Restart a script when project files change\n\n",
+                "\x1b[2mUSAGE:\x1b[0m\n",
+                "    kipferl dev [OPTIONS] <script.py> [--] [args...]\n\n",
+                "\x1b[2mOPTIONS:\x1b[0m\n",
+                "    -w, --watch <path>    Watch an additional file or directory\n",
+                "    --clear               Clear the terminal before each restart\n",
+                "    --debounce <ms>       Wait for writes to settle (default: 150)\n",
+                "    -h, --help            Show this help\n\n",
+                "\x1b[2mDESCRIPTION:\x1b[0m\n",
+                "    Runs the script immediately, then watches its directory recursively.\n",
+                "    The watcher stays alive when the script exits so the next edit runs it\n",
+                "    again. Generated, cache, virtual-environment, and VCS paths are ignored.\n\n",
+                "\x1b[2mEXAMPLES:\x1b[0m\n",
+                "    kipferl dev app.py\n",
+                "    kipferl dev --clear app.py\n",
+                "    kipferl dev --watch templates --watch settings.toml app.py -- --verbose\n",
             )
         );
         assert_eq!(

--- a/crates/kipferl-cli/src/run_command.rs
+++ b/crates/kipferl-cli/src/run_command.rs
@@ -128,7 +128,7 @@ pub(crate) fn prepare_runtime() -> io::Result<PathBuf> {
     Ok(runtime_path)
 }
 
-fn prepare_transformed_script(script_path: &Path) -> io::Result<PathBuf> {
+pub(crate) fn prepare_transformed_script(script_path: &Path) -> io::Result<PathBuf> {
     let source = fs::read(script_path)?;
     if source.len() > MAX_SCRIPT_SIZE {
         return Err(io::Error::new(

--- a/crates/kipferl-cli/tests/cli.rs
+++ b/crates/kipferl-cli/tests/cli.rs
@@ -1,8 +1,11 @@
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::time::Duration;
 
 static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -45,6 +48,10 @@ fn reports_version_help_and_unknown_commands() {
     assert!(run_help.status.success());
     assert!(text(&run_help.stdout).contains("kipferl run <script.py> [args...]"));
 
+    let dev_help = run(&temporary, &["dev", "--help"]);
+    assert!(dev_help.status.success());
+    assert!(text(&dev_help.stdout).contains("kipferl dev [OPTIONS] <script.py>"));
+
     let no_script = run(&temporary, &["run"]);
     assert!(!no_script.status.success());
     assert_eq!(
@@ -58,6 +65,53 @@ fn reports_version_help_and_unknown_commands() {
         text(&missing_script.stderr),
         "\x1b[31mError:\x1b[0m Script not found: missing.py\n"
     );
+}
+
+#[test]
+fn dev_runs_immediately_and_restarts_after_an_edit() {
+    let temporary = TestDirectory::new("dev restart");
+    let project = temporary.path.join("project");
+    fs::create_dir(&project).expect("create project directory");
+    let script = project.join("app.py");
+    let config = temporary.path.join("settings.txt");
+    fs::write(&script, "print('first run')\n").expect("write initial script");
+    fs::write(&config, "initial settings\n").expect("write watched config");
+
+    let process = Command::new(env!("CARGO_BIN_EXE_kipferl"))
+        .args([
+            "dev",
+            "--debounce",
+            "25",
+            "--watch",
+            "settings.txt",
+            "project/app.py",
+        ])
+        .current_dir(&temporary.path)
+        .env("KIPFERL_CACHE_DIR", temporary.path.join(".cache"))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start dev command");
+    let mut process = ChildGuard(process);
+    let stdout = process.0.stdout.take().expect("capture dev stdout");
+    let (lines, received) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            if lines.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    wait_for_output(&received, "first run");
+    fs::write(&config, "changed settings\n").expect("edit extra watched file");
+    wait_for_output(&received, "Change detected, restarting");
+    wait_for_output(&received, "first run");
+    fs::write(&script, "print('script edit')\n").expect("edit watched script");
+    wait_for_output(&received, "Change detected, restarting");
+    wait_for_output(&received, "script edit");
+
+    process.stop();
 }
 
 #[test]
@@ -379,8 +433,39 @@ fn text(bytes: &[u8]) -> String {
     String::from_utf8_lossy(bytes).into_owned()
 }
 
+fn wait_for_output(lines: &mpsc::Receiver<String>, expected: &str) {
+    let mut observed = Vec::new();
+    loop {
+        let line = lines
+            .recv_timeout(Duration::from_secs(10))
+            .unwrap_or_else(|error| {
+                panic!("timed out waiting for {expected:?}: {error}; output: {observed:?}")
+            });
+        let matches = line.contains(expected);
+        observed.push(line);
+        if matches {
+            return;
+        }
+    }
+}
+
 struct TestDirectory {
     path: PathBuf,
+}
+
+struct ChildGuard(std::process::Child);
+
+impl ChildGuard {
+    fn stop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        self.stop();
+    }
 }
 
 impl TestDirectory {

--- a/tests/compat_report_pocketpy.md
+++ b/tests/compat_report_pocketpy.md
@@ -1,6 +1,6 @@
 # Kipferl Compatibility Report
 
-Generated: 2026-08-05 11:01:50
+Generated: 2026-08-05 12:29:58
 
 ## Summary
 

--- a/website/content/docs/getting-started/quick-start.mdx
+++ b/website/content/docs/getting-started/quick-start.mdx
@@ -48,11 +48,18 @@ elif action == "Exit":
         tui.error("Goodbye!")
 ```
 
-## Run It
+## Develop It
 
 ```bash
-kipferl run app.py
+kipferl dev app.py
 ```
+
+Kipferl runs the app immediately and restarts it whenever a Python, config, or
+template file in the app directory changes. The watcher stays open after the
+app exits, so save `app.py` to run it again. Add `--clear` to clear the terminal
+between runs or `--watch <path>` to include any file or directory elsewhere.
+
+For a one-off run without watching, use `kipferl run app.py`.
 
 ## Build a Binary
 

--- a/website/src/components/Terminal.tsx
+++ b/website/src/components/Terminal.tsx
@@ -170,7 +170,9 @@ export function Terminal({
 
 // Pre-styled terminal output examples
 export function TerminalDemo() {
-  const demoOutput = `\x1b[36m$\x1b[0m kipferl run demo.py
+  const demoOutput = `\x1b[36m$\x1b[0m kipferl dev demo.py
+\x1b[1;32mKipferl dev\x1b[0m \x1b[2mwatching ./\x1b[0m
+\x1b[36m→\x1b[0m Running \x1b[1mdemo.py\x1b[0m
 
 \x1b[1;34m╭─ Release ─────────────────────────────╮\x1b[0m
 \x1b[1;34m│\x1b[0m Deploying build...                    \x1b[1;34m│\x1b[0m


### PR DESCRIPTION
## What changed

- add `kipferl dev` with native filesystem events through `notify`
- restart scripts after a 150 ms debounce, remain alive after script exit, and recover from atomic-save gaps
- support repeatable `--watch`, `--clear`, and configurable `--debounce`
- restore terminal state between restarts for interactive Ratatui applications
- ignore generated paths and application output by default while watching Python, config, and template files recursively
- document the development loop in the README, website quick start, launch plan, and Rust migration roadmap

## Why

The Rust migration should ship a polished local feedback loop before the stable v0.6.0 release. A maintained cross-platform watcher is safer and easier to maintain than bespoke FSEvents/inotify implementations.

## Developer impact

`kipferl dev app.py` now runs immediately and automatically restarts after relevant edits. Explicit watch targets can include other files or entire directories.

The optimized macOS ARM64 CLI grows from 4,796,384 to 4,866,224 bytes (+69,840 bytes, about 1.5%) and remains below the 6 MB CLI budget.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- dedicated end-to-end initial-run, extra-watch, and script-restart coverage
- all four release targets type-check; both macOS release targets link locally
- compatibility: 1,669/1,669
- vision suite: 19/19
- website Biome, TypeScript, and production Next.js build
- optimized CLI: 4,866,224 bytes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `kipferl dev` for automatic script restarts when watched files change.
  * Supports recursive project watching, custom watch paths, debouncing, terminal clearing, and help options.
  * Restores the terminal after development sessions and reports runtime or watcher errors clearly.

* **Documentation**
  * Updated the README, quick start guide, website examples, and release roadmaps with development-mode workflows.
  * Clarified the distinction between `kipferl dev` and one-off execution with `kipferl run`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->