### PR TITLE
Harden release note metadata

### DIFF
--- a/.github/scripts/generate_release_notes.py
+++ b/.github/scripts/generate_release_notes.py
@@ -48,15 +48,61 @@ def parse_commits(raw_commits: str) -> list[dict]:
     return commits
 
 
-def installation_guidance(current_tag: str) -> str:
-    """Return release-note installation rules for stable or prerelease tags."""
+def installation_section(current_tag: str, repo: str) -> str:
+    """Return deterministic installation instructions for a release."""
     if "-" in current_tag:
-        return """This is a prerelease. Do not suggest Homebrew, because prereleases do not update the stable formula. Tell users to download the matching `kipferl-*` asset and adjacent `.sha256` file from the GitHub release. Mention that temporary `ucharm-*` compatibility assets are also published for existing automation."""
-    return """Use the stable Homebrew commands:
+        return f"""### Installation
+
+This is a prerelease. Download the matching CLI and adjacent `.sha256` file
+from the [{current_tag} GitHub release](https://github.com/{repo}/releases/tag/{current_tag}):
+
+- `kipferl-macos-aarch64` — macOS Apple Silicon
+- `kipferl-macos-x86_64` — macOS Intel
+- `kipferl-linux-aarch64` — Linux ARM64, static musl
+- `kipferl-linux-x86_64` — Linux x86_64, static musl
+
+Temporary `ucharm-*` compatibility assets remain available for existing
+automation during the v0.6 transition."""
+    return """### Installation
+
 ```bash
 brew install niklas-heer/tap/kipferl
 brew upgrade kipferl
 ```"""
+
+
+def assemble_release_notes(
+    generated: str,
+    current_tag: str,
+    prev_tag: Optional[str],
+    repo: str,
+) -> str:
+    """Add factual installation and changelog sections outside the AI output."""
+    sections = [generated.strip(), installation_section(current_tag, repo)]
+    if prev_tag:
+        sections.append(
+            f"---\n\n**Full changelog:** "
+            f"https://github.com/{repo}/compare/{prev_tag}...{current_tag}"
+        )
+    return "\n\n".join(sections)
+
+
+def validate_generated_summary(generated: str) -> None:
+    """Reject AI-owned metadata so the deterministic fallback takes over."""
+    normalized = generated.casefold()
+    forbidden = (
+        "http://",
+        "https://",
+        "### installation",
+        "## installation",
+        "brew install",
+        "brew upgrade",
+        "kipferl-macos-",
+        "kipferl-linux-",
+        "full changelog",
+    )
+    if any(value in normalized for value in forbidden):
+        raise ValueError("generated summary contains release metadata")
 
 
 def generate_release_notes_with_ai(
@@ -78,8 +124,6 @@ def generate_release_notes_with_ai(
         commits_context.append(commit_text)
 
     commits_text = "\n\n".join(commits_context)
-
-    installation = installation_guidance(current_tag)
 
     prompt = f"""You are writing release notes for "kipferl" (Kipferl), a CLI toolkit for building beautiful, fast command-line applications with Python syntax. The production CLI, universal loader, native modules, and PocketPy host are implemented in Rust. PocketPy itself is vendored C. Supported release targets are macOS ARM64, macOS x86_64, Linux ARM64 musl, and Linux x86_64 musl. Typical runtime artifacts are 4-5 MB and start in about 8 ms on Apple Silicon.
 
@@ -103,9 +147,6 @@ Generate polished, engaging release notes in markdown. Follow the style of polis
    - 🐛 **Bug Fixes** — Corrected issues
    - 📚 **Documentation** — Docs and examples (only if significant)
 
-3. **Installation** (always include):
-   {installation}
-
 ## Style Guidelines:
 
 - **Tone**: Friendly and approachable, like talking to a fellow developer
@@ -115,6 +156,7 @@ Generate polished, engaging release notes in markdown. Follow the style of polis
 - **Accuracy**: Do not invent targets, metrics, compatibility counts, size claims, or installation methods. Never claim Windows support. Only use numbers present in the commits or the product facts above.
 - **No commit hashes** in the output
 - **Present tense**: "Add" not "Added"
+- **Scope**: Do not write installation commands, download links, asset names, or a full changelog link. The generator appends those facts deterministically.
 
 ## Example Output:
 
@@ -135,12 +177,6 @@ Interactive prompts have arrived! Build beautiful CLI experiences with select me
 
 - Fix box rendering when content contains ANSI color codes
 - Correct cursor positioning after multiselect prompts
-
-### Installation
-
-Follow the installation rule supplied above for the current tag.
-
----
 
 Generate the release notes now, starting with the opening tagline."""
 
@@ -164,12 +200,9 @@ Generate the release notes now, starting with the opening tagline."""
     response.raise_for_status()
     result = response.json()
 
-    release_notes = result["choices"][0]["message"]["content"].strip()
-
-    if prev_tag:
-        release_notes += f"\n\n---\n\n**Full Changelog**: https://github.com/{repo}/compare/{prev_tag}...{current_tag}"
-
-    return release_notes
+    generated = result["choices"][0]["message"]["content"].strip()
+    validate_generated_summary(generated)
+    return assemble_release_notes(generated, current_tag, prev_tag, repo)
 
 
 def main():
@@ -212,7 +245,9 @@ def main():
 
     if not commits:
         print("No commits found. Generating minimal release notes.", file=sys.stderr)
-        release_notes = f"Release {current_tag}"
+        release_notes = assemble_release_notes(
+            f"Release {current_tag}", current_tag, prev_tag, repo
+        )
     else:
         try:
             release_notes = generate_release_notes_with_ai(
@@ -227,12 +262,12 @@ def main():
             print(f"Error calling OpenRouter API: {e}", file=sys.stderr)
             print("Falling back to basic release notes", file=sys.stderr)
 
-            release_notes = "## Changes\n\n"
-            for commit in commits:
-                release_notes += f"- {commit['subject']}\n"
-
-            if prev_tag:
-                release_notes += f"\n\n**Full Changelog**: https://github.com/{repo}/compare/{prev_tag}...{current_tag}"
+            changes = "## Changes\n\n" + "\n".join(
+                f"- {commit['subject']}" for commit in commits
+            )
+            release_notes = assemble_release_notes(
+                changes, current_tag, prev_tag, repo
+            )
 
     print(release_notes)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -6,7 +6,7 @@ This is the single source of truth for priorities and next steps.
 
 - Goal: build beautiful CLI apps with Python syntax, shipped as compact, fast,
   standalone binaries.
-- Runtime: PocketPy; the Rust host, loader, CLI, 51 fully compatible stdlib targets, and Cargo-first release path are implemented. Rust prerelease `v0.6.0-rc.1` is published and proven.
+- Runtime: PocketPy; the Rust host, loader, CLI, 51 fully compatible stdlib targets, and Cargo-first release path are implemented. Rust prerelease `v0.6.0-rc.2` is published and proven.
 - Language decision: Rust is the target implementation language. See `RUST_MIGRATION.md` for gates and sequencing.
 - Compatibility status: the Rust runtime passes 1,669/1,669 available checks (100%), with 51/52 targeted modules at 100% parity, no partial modules, and one host-unavailable `toml` baseline. Refresh with `python3 tests/compat_runner.py --runtime target/release/pocketpy-kipferl --report`.
 - PocketPy vendor patches are tracked under `pocketpy/patches/` and verified via `python3 scripts/verify-pocketpy-patches.py --check-upstream`.
@@ -67,16 +67,15 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
 
 1. The measured Rust-native optimization and safety review is complete and
    frozen in `benchmarks/rust_optimization_baseline.md`.
-2. Rust prerelease `v0.6.0-rc.1` passed both four-target CI matrices, the tagged
-   release workflow, checksum verification, and an external universal-app
-   smoke test without updating stable Homebrew.
+2. Rust prerelease `v0.6.0-rc.2` passed both four-target CI matrices, the tagged
+   release workflow, checksum verification, and external `kipferl dev` restart
+   validation from the downloaded artifact without updating stable Homebrew.
 3. The archived Zig implementation is removed. The public README, website,
    docs, templates, and examples now describe the Rust architecture and RC;
    the website publishes the measured migration retrospective below.
-4. Canonical stub generation, release evidence, and cross-target build
-   verification are complete. Publish and validate `v0.6.0-rc.2` with
-   `kipferl dev`, allow a short feedback window, then promote the same proven
-   Rust line to stable `v0.6.0`.
+4. Canonical stub generation, release evidence, cross-target build verification,
+   and the `v0.6.0-rc.2` public bake are complete. Allow a short feedback window,
+   then promote the same proven Rust line to stable `v0.6.0`.
 
 ## Product Roadmap After the Rust Cutover
 
@@ -231,8 +230,8 @@ The detailed inventory, architecture, acceptance gates, PR sequence, and risks a
 
 ## Backlog (ordered)
 
-- Publish and validate `v0.6.0-rc.2`, then promote the proven Rust release to
-  stable `v0.6.0` after its feedback window.
+- Promote the validated Rust release to stable `v0.6.0` after the RC2 feedback
+  window.
 - Tree-shaking or module selection for smaller binaries, after stable; pursue
   it only when the DX and maintenance tradeoff is favorable.
 - Formats: third-party `toml` and YAML.

--- a/RUST_MIGRATION.md
+++ b/RUST_MIGRATION.md
@@ -9,10 +9,10 @@ not change the compatibility contract.
 
 The runtime implementation reached 1,669/1,669 available compatibility checks
 on 2026-08-04. The Cargo-first CI, packaging, public binary names, and release
-assets have been cut over to Rust. Public prerelease `v0.6.0-rc.1`, released
-under the predecessor name, passed both four-target CI matrices, the tagged
-release workflow, published-checksum
-verification, and a downloaded universal-app smoke test. v0.5.0 remains the
+assets have been cut over to Rust. Public prerelease `v0.6.0-rc.2`, released
+as Kipferl, passed both four-target CI matrices, the tagged release workflow,
+published-checksum verification, and a downloaded `kipferl dev` edit/restart
+smoke test. v0.5.0 remains the
 final stable Zig release baseline.
 
 This is a host-language and toolchain migration, not a product rewrite. The

--- a/scripts/test_release_notes.py
+++ b/scripts/test_release_notes.py
@@ -12,17 +12,56 @@ SPEC.loader.exec_module(release_notes)
 
 class InstallationGuidanceTests(unittest.TestCase):
     def test_prerelease_uses_direct_downloads(self):
-        guidance = release_notes.installation_guidance("v0.6.0-rc.1")
+        guidance = release_notes.installation_section(
+            "v0.6.0-rc.2", "niklas-heer/kipferl"
+        )
 
         self.assertIn("prerelease", guidance)
         self.assertIn(".sha256", guidance)
+        self.assertIn("kipferl-macos-aarch64", guidance)
+        self.assertIn("kipferl-linux-x86_64", guidance)
+        self.assertIn(
+            "https://github.com/niklas-heer/kipferl/releases/tag/v0.6.0-rc.2",
+            guidance,
+        )
         self.assertNotIn("brew install", guidance)
 
     def test_stable_release_uses_homebrew(self):
-        guidance = release_notes.installation_guidance("v0.6.0")
+        guidance = release_notes.installation_section(
+            "v0.6.0", "niklas-heer/kipferl"
+        )
 
         self.assertIn("brew install niklas-heer/tap/kipferl", guidance)
         self.assertIn("brew upgrade kipferl", guidance)
+
+    def test_assembly_owns_links_and_asset_names(self):
+        notes = release_notes.assemble_release_notes(
+            "A concise generated summary.",
+            "v0.6.0-rc.2",
+            "v0.6.0-rc.1",
+            "niklas-heer/kipferl",
+        )
+
+        self.assertTrue(notes.startswith("A concise generated summary."))
+        self.assertIn("kipferl-linux-aarch64", notes)
+        self.assertIn(
+            "https://github.com/niklas-heer/kipferl/compare/"
+            "v0.6.0-rc.1...v0.6.0-rc.2",
+            notes,
+        )
+
+    def test_generated_summary_cannot_override_release_metadata(self):
+        release_notes.validate_generated_summary("Add a reliable watch mode.")
+
+        for invalid in (
+            "### Installation\nDownload kipferl-macos-arm64",
+            "See https://github.com/wrong/project/releases",
+            "brew install something/else",
+            "Full changelog: made up",
+        ):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    release_notes.validate_generated_summary(invalid)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The public v0.6.0-rc.2 validation exposed a release-note reliability gap: AI-generated prose invented an old repository URL and asset suffixes that do not exist.

This change keeps the useful generated summary while making all operational metadata deterministic:

- generate installation instructions from the actual repository and tag
- list the exact published asset names for prereleases
- emit the stable Homebrew commands only for stable releases
- append the canonical full-changelog URL in code
- reject AI output that tries to own links, installation instructions, asset names, or changelog metadata and fall back safely
- record the completed and externally validated RC2 milestone in the migration plan

## Validation

- `python3 scripts/test_release_notes.py`
- `python3 scripts/test_release.py`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

Related to #3.